### PR TITLE
Fix Friends panel Add Friend/Challenge labels

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -61,6 +61,12 @@ All notable changes to Accessible Arena.
 - Uses `HandleEarlyInput()` hook to route popup input before BaseNavigator's auto-focus logic can intercept it
 - Files: BaseNavigator.cs, GeneralMenuNavigator.cs, SettingsMenuNavigator.cs
 
+### Fixed: Friends Panel Add Friend/Challenge Labels
+- FriendsWidget action buttons now prefer localized tooltip/locale text instead of cleaned GameObject names
+- `Button_AddFriend` and `Button_AddChallenge` now resolve to locale keys when no direct label text is present
+- Tooltip fallback now checks parent containers so hitbox children can use their parent `TooltipTrigger` localization
+- Files: UITextExtractor.cs
+
 ## v0.7.2 - 2026-02-26
 
 ### New: Land Summary Shortcut (M / Shift+M)

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -55,14 +55,6 @@ Starting a bot match from the "Recent Played" section does not work properly.
 
 ---
 
-### Friends Panel "add friend" / "add challenge" Buttons Show English Labels
-
-The "add friend" and "add challenge" buttons in the FriendsWidget show English GameObject names instead of localized text. Our text extraction falls back to the GameObject name (`Button_AddFriend`, `Button_AddChallenge`) when it can't find the localized TextMeshProUGUI label. The actual localized text likely lives on a child object or uses a different text component that we miss.
-
-**Path:** `FriendsWidget_Desktop_16x9(Clone)/FriendWidget_Base/Button_AddFriend/Backer_Hitbox`
-
----
-
 ### Haide Land Browser Broken (Leicht Gepanzert Deck)
 
 The Haide land (from the "Leicht Gepanzert" Brawl deck) opens a color picker browser to choose a mana color except white. This browser is not handled correctly and breaks navigation.


### PR DESCRIPTION
## What changed
- Fixed Friends panel action labels so they use proper localized labels instead of fallback object-name text.
- `Add Friend` and `Start Challenge` now resolve through localized sources for FriendsWidget hitboxes.
- Tooltip label fallback now checks parent containers too (needed for hitbox child objects).

## Why
In FriendsWidget, some clickable elements are hitbox children with no direct text. That caused label fallback to rely on cleaned GameObject names. This change prioritizes localized tooltip/locale paths so announcements are correct and stable.

## How we tested
Human in-game testing (English client):
1. Opened Friends panel.
2. Navigated to `Add Friend` and `Start Challenge` entries.
3. Confirmed announcements are `Add Friend, button` and `Start Challenge, button`.
4. Activated both entries:
   - `Add Friend` opened the friend request popup.
   - `Start Challenge` opened direct challenge flow.

Build/test command run locally:
- `dotnet build src/AccessibleArena.csproj --no-restore`

## Files updated
- `src/Core/Services/UITextExtractor.cs`
- `docs/CHANGELOG.md`
- `docs/KNOWN_ISSUES.md`

## Attribution
- AI-assisted implementation: Codex (chatgpt-codex-connector bot)
- Human validation/testing: `blindndangerous`