### PR TITLE
Fix Color Challenge: deck name refresh and Backspace navigation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to Accessible Arena.
 - Selecting a different color in Color Challenge now triggers a UI rescan
 - The announced deck name updates to reflect the newly selected color's deck
 
+### Fixed: Color Challenge Backspace Navigation
+- Backspace now re-expands the color list when a color is selected (blade collapsed)
+- Backspace from the color list (blade expanded) still navigates Home
+- Previously Backspace always went Home regardless of blade state
+
 ## v0.8.1
 
 ### New: Local Release Script

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -28,7 +28,7 @@ Starting a bot match from the "Recent Played" section does not work properly.
 
 ~~When selecting a different color in Color Challenge, the announced deck name does not update to reflect the newly selected color's deck.~~
 
-Fixed: Selecting a color button now triggers a rescan so the deck name refreshes.
+Fixed: Selecting a color button now triggers a rescan so the deck name refreshes. Backspace from a selected color now re-expands the color list instead of going Home.
 
 ---
 

--- a/src/Core/Services/GeneralMenuNavigator.cs
+++ b/src/Core/Services/GeneralMenuNavigator.cs
@@ -1691,12 +1691,28 @@ namespace AccessibleArena.Core.Services
 
         /// <summary>
         /// Handle back navigation in Color Challenge (CampaignGraph).
-        /// CampaignGraph has no game-native back-to-PlayBlade mechanism,
-        /// so we navigate Home to exit.
+        /// Two-level back:
+        /// - Blade collapsed (a color is selected, deck shown) → expand blade to return to color list.
+        /// - Blade expanded (color list visible) → navigate Home to exit Color Challenge.
         /// </summary>
         private bool HandleCampaignGraphBack()
         {
-            LogDebug($"[{NavigatorId}] CampaignGraph: navigating Home");
+            // Check if blade is currently collapsed by looking for the expand button
+            var bladeButton = GetActiveCustomButtons()
+                .FirstOrDefault(obj => obj.name.Contains("BladeHoverClosed") || obj.name.Contains("Btn_BladeIsClosed"));
+
+            if (bladeButton != null)
+            {
+                // Blade is collapsed (a color is selected) — re-expand to show color list
+                LogDebug($"[{NavigatorId}] CampaignGraph back: blade collapsed, re-expanding color list");
+                _announcer.Announce(Models.Strings.OpeningColorChallenges, Models.AnnouncementPriority.High);
+                UIActivator.Activate(bladeButton);
+                TriggerRescan();
+                return true;
+            }
+
+            // Blade is expanded (color list visible) — exit Color Challenge
+            LogDebug($"[{NavigatorId}] CampaignGraph back: blade expanded, navigating Home");
             _announcer.AnnounceVerbose(Models.Strings.NavigatingBack, Models.AnnouncementPriority.High);
             return NavigateToHome();
         }


### PR DESCRIPTION
Two related fixes for Color Challenge (CampaignGraph) navigation.

## Fix 1: Deck name not refreshing on color selection

When selecting a color button in Color Challenge, the blade collapses to show the selected color's deck. Previously no rescan was triggered, so the announced deck name remained stale from the previous selection.

**Fix:** Added `TriggerRescan()` after activating a blade element in `CampaignGraphContentController` mode. The element list now refreshes with the correct deck name after each color selection.

## Fix 2: Backspace always returning Home

The back navigation for CampaignGraph previously always navigated Home regardless of blade state. This forced users to re-enter Color Challenge every time they wanted to try a different color.

**Fix:** `HandleCampaignGraphBack()` now checks for the blade expand button:
- Blade collapsed (color selected, deck showing) → re-expands the color list
- Blade expanded (color list visible) → navigates Home

## Files changed

- `src/Core/Services/GeneralMenuNavigator.cs` — rescan trigger in `OnElementActivated`, two-level back in `HandleCampaignGraphBack()`
- `docs/KNOWN_ISSUES.md` — marked fixed
- `docs/CHANGELOG.md` — Unreleased section entries

## Testing

Verified in-game (log evidence):
- Selecting White → "Aerial Domination, deck" announced ✓
- Selecting Red → "Keep the Peace, deck" announced ✓
- Backspace from selected color re-announces color list ("Opening color challenges") ✓

---

AI-assisted implementation: GitHub Copilot (Claude Sonnet 4.6)
Human testing/verification: blindndangerous