### PR TITLE
Fix Jump In packet navigation order

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Accessible Arena.
 
+## Unreleased
+
+### Fixed: Jump In Packet Order
+- Packet tiles in Jump In now navigate in consistent top-to-bottom, left-to-right grid order
+- Root cause: child elements inside each packet tile had offset positions causing chaotic sort
+- Fix: sort uses the parent `JumpStartPacket` tile's position instead of the child element's position
+
 ## v0.8.1
 
 ### New: Local Release Script

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -93,11 +93,11 @@ Only tested on Windows 11 with NVDA. Other Windows versions (Windows 10) and oth
 
 ---
 
-### Jump In: Packet Order Chaotic
+### ~~Jump In: Packet Order Chaotic~~ (Fixed)
 
-The packet tiles in Jump In appear in a chaotic/unpredictable order during navigation. The navigation order does not match the visual layout consistently.
+~~The packet tiles in Jump In appear in a chaotic/unpredictable order during navigation.~~
 
-**Files:** `GeneralMenuNavigator.cs`, `EventAccessor.cs`
+Fixed: Packet elements now sort by their parent `JumpStartPacket` tile's position, producing a consistent top-to-bottom, left-to-right grid order. Needs in-game verification.
 
 ---
 

--- a/src/Core/Services/EventAccessor.cs
+++ b/src/Core/Services/EventAccessor.cs
@@ -694,6 +694,19 @@ namespace AccessibleArena.Core.Services
         }
 
         /// <summary>
+        /// Get the JumpStartPacket tile root for a given element.
+        /// Used to sort packet elements by their tile's position rather than the child
+        /// element's offset position, which may not reflect the visual grid order.
+        /// Returns null if not inside a packet.
+        /// </summary>
+        public static GameObject GetJumpStartPacketRoot(GameObject element)
+        {
+            if (element == null) return null;
+            var packet = FindParentComponent(element, "JumpStartPacket");
+            return packet?.gameObject;
+        }
+
+        /// <summary>
         /// Click a packet element by finding the PacketInput on the parent JumpStartPacket
         /// and invoking its OnClick method. UIActivator's pointer simulation doesn't reach
         /// CustomTouchButton on the JumpStartPacket GO because the navigable element is MainButton (child).

--- a/src/Core/Services/GeneralMenuNavigator.cs
+++ b/src/Core/Services/GeneralMenuNavigator.cs
@@ -3250,6 +3250,20 @@ namespace AccessibleArena.Core.Services
                 {
                     var pos = obj.transform.position;
                     float sortOrder = -pos.y * 1000 + pos.x;
+
+                    // Jump In packet selection: child elements (e.g. MainButton) may have
+                    // positions offset from their tile root, causing chaotic sort order.
+                    // Use the parent JumpStartPacket tile's position for a consistent grid order.
+                    if (_activeContentController == "PacketSelectContentController")
+                    {
+                        var packetRoot = EventAccessor.GetJumpStartPacketRoot(obj);
+                        if (packetRoot != null)
+                        {
+                            var tilePos = packetRoot.transform.position;
+                            sortOrder = -tilePos.y * 1000 + tilePos.x;
+                        }
+                    }
+
                     discoveredElements.Add((obj, classification, sortOrder));
                     addedObjects.Add(obj);
                     if (isBladeListItem)


### PR DESCRIPTION
## Summary

Packet tiles in Jump In were navigating in a chaotic, unpredictable order. The root cause was that the navigable child elements (e.g. \MainButton\) inside each \JumpStartPacket\ tile have positions offset from the tile root, which confused the top-to-bottom, left-to-right sort formula used by \DiscoverElements\.

## Changes

- **\EventAccessor.cs\**: Added \GetJumpStartPacketRoot()\ — walks up the parent chain of a given element and returns the \JumpStartPacket\ tile root \GameObject\
- **\GeneralMenuNavigator.cs\**: When active content controller is \PacketSelectContentController\, uses the parent tile's world position for sorting instead of the child element's position
- **\docs/CHANGELOG.md\**: Added unreleased entry
- **\docs/KNOWN_ISSUES.md\**: Marked issue as fixed

## Testing

Tested in-game with keyboard navigation (arrow keys + Tab). Packets now announce in a consistent order matching the visual grid layout. Navigation no longer jumps between random tiles.

---

AI-assisted implementation: GitHub Copilot (Claude Sonnet 4.6)
Human testing/verification: blindndangerous