### PR TITLE
Add Color Challenge node info blocks with status and rewards

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Accessible Arena.
 
+## Unreleased
+
+### New: Color Challenge node info blocks
+- When on the Color Challenge screen, challenge node info is now accessible via Up/Down navigation
+- Each objective node (I through V) shows its status (Completed, Current, Available, Locked)
+- Shows match type for each node (PvP Match or AI Match)
+- Shows reward text from the game's data model when available (e.g., gold, wildcards, card styles)
+- Indicates when a node includes a deck upgrade (new cards added)
+- Reward popup text (title and description) is included when the bubble popup is visible
+- Falls back to track-level summary (e.g., "3 of 5 nodes unlocked") when node display is not active
+- Info blocks refresh automatically when switching between colors
+- Filters out developer placeholder text in reward descriptions
+- Reads directly from the game's CampaignGraphTrackModule, objective bubbles, and strategy node data
+
 ## v0.8.1
 
 ### New: Local Release Script

--- a/lang/de.json
+++ b/lang/de.json
@@ -738,6 +738,15 @@
   "EventScreenTitle_Format": "Event: {0}",
   "PacketOf_Format": "Paket {0} von {1}",
   "EventInfoLabel": "Info",
+  "ColorChallengeProgress_Format": "{0}: {1} of {2} nodes unlocked",
+  "ColorChallengeTrackComplete_Format": "{0}: track complete",
+  "ColorChallengeComplete": "Track complete",
+  "ColorChallengeProgressNoTrack_Format": "{0} of {1} nodes unlocked",
+  "ColorChallengeNode_Format": "Challenge {0}",
+  "ColorChallengeNodeCompleted": "Completed",
+  "ColorChallengeNodeCurrent": "Current",
+  "ColorChallengeNodeLocked": "Locked",
+  "ColorChallengeNodeAvailable": "Available",
   "FullControl_On": "Volle Kontrolle an",
   "FullControl_Off": "Volle Kontrolle aus",
   "FullControl_Locked": "Volle Kontrolle gesperrt",
@@ -803,5 +812,9 @@
   "ChooseX_CannotSubmit": "Aktueller Wert kann nicht bestätigt werden",
   "KeywordSelection_Entry_Format": "Schlüsselwort wählen. {0} Optionen. Tab zum Navigieren, Enter zum Auswählen, Leertaste zum Bestätigen",
   "KeywordSelection_Selected": "ausgewählt",
-  "KeywordSelection_Toggled_Format": "{0}, {1}"
+  "KeywordSelection_Toggled_Format": "{0}, {1}",
+  "ColorChallengeMatchPvP": "PvP Match",
+  "ColorChallengeMatchAI": "AI Match",
+  "ColorChallengeDeckUpgrade": "Deck Upgrade",
+  "ColorChallengeReward_Format": "Reward: {0}"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -6,13 +6,11 @@
   "NoNextItem": "No next item",
   "NoPreviousItem": "No previous item",
   "ItemDisabled": "Item is disabled",
-
   "Activating_Format": "Activating {0}",
   "CannotActivate_Format": "Cannot activate {0}",
   "CouldNotPlay_Format": "Could not play {0}",
   "NoAbilityAvailable_Format": "{0} has no activatable ability",
   "NoCardSelected": "No card selected",
-
   "NavigateWithArrows": "Arrow keys to navigate",
   "BeginningOfList": "Beginning of list",
   "EndOfList": "End of list",
@@ -31,11 +29,9 @@
   "ClosingSettings": "Closing settings",
   "ClosingPlayBlade": "Closing play menu",
   "ExitingDeckBuilder": "Exiting deck builder",
-
   "DeckInfoCardCount": "Card Count",
   "DeckInfoManaCurve": "Mana Curve",
   "DeckInfoTypeBreakdown": "Types",
-
   "DeckSelected": "selected",
   "DeckStatus_Unavailable": "unavailable",
   "DeckStatus_Invalid": "invalid deck",
@@ -43,7 +39,6 @@
   "DeckStatus_MissingCards": "missing cards",
   "DeckStatus_MissingCardsCraftable": "missing cards, craftable",
   "DeckStatus_InvalidCompanion": "invalid companion",
-
   "BirthYearField": "Birth year field. Use arrow keys to select year.",
   "BirthMonthField": "Birth month field. Use arrow keys to select month.",
   "BirthDayField": "Birth day field. Use arrow keys to select day.",
@@ -58,7 +53,6 @@
   "CheckingQueuePosition": "Checking queue position...",
   "OpeningSupportWebsite": "Opening support website...",
   "NoTermsContentFound": "No terms content found",
-
   "EndOfBattlefield": "End of battlefield",
   "BeginningOfBattlefield": "Beginning of battlefield",
   "EndOfRow": "End of row",
@@ -67,38 +61,32 @@
   "RowWithCount_One": "{0}, 1 card",
   "RowWithCount_Format": "{0}, {1} cards",
   "RowEmptyShort_Format": "{0}, empty",
-
   "LandSummary_Empty_Format": "{0}, no lands",
   "LandSummary_Total_One": "1 land",
   "LandSummary_Total_Format": "{0} lands",
   "LandSummary_AllTapped_Format": "{0}, all tapped",
   "LandSummary_AllUntapped_Format": "{0}, {1} untapped",
   "LandSummary_Mixed_Format": "{0}, {1} untapped",
-
   "EndOfZone": "End of zone",
   "BeginningOfZone": "Beginning of zone",
   "ZoneNotFound_Format": "{0} not found",
   "ZoneEmpty_Format": "{0}, empty",
   "ZoneWithCount_One": "{0}, 1 card",
   "ZoneWithCount_Format": "{0}, {1} cards",
-
   "NoValidTargets": "No valid targets",
   "NoTargetSelected": "No target selected",
   "TargetingCancelled": "Targeting cancelled",
   "SelectTargetNoValid": "Select a target. No valid targets found.",
   "Targeted_Format": "Targeted {0}",
   "CouldNotTarget_Format": "Could not target {0}",
-
   "NoPlayableCards": "No playable cards",
   "SpellCast": "Spell cast",
   "SpellCastPrefix": "Cast",
   "SpellUnknown": "unknown spell",
   "ResolveStackFirst": "Resolve stack first. Press Space to resolve or Tab to select targets.",
-
   "AbilityTriggered": "triggered",
   "AbilityActivated": "activated",
   "AbilityUnknown": "Ability",
-
   "NoSubmitButtonFound": "No submit button found",
   "CouldNotSubmitDiscard": "Could not submit discard",
   "DiscardCount_One": "Discard 1 card",
@@ -109,10 +97,8 @@
   "NeedHaveSelected_Format": "Need {0}, have {1} selected",
   "SubmittingDiscard_Format": "Submitting {0} cards for discard",
   "CouldNotSelect_Format": "Could not select {0}",
-
   "EndOfCard": "End of card",
   "BeginningOfCard": "Beginning of card",
-
   "CardInfoName": "Name",
   "CardInfoQuantity": "Quantity",
   "CardInfoCollection": "Collection",
@@ -124,13 +110,10 @@
   "CardInfoRarity": "Rarity",
   "CardInfoArtist": "Artist",
   "CardInfoSetAndArtist": "Set and Artist",
-
   "CardQuantityMissing_Format": "{0}, missing",
   "CardOwned_Format": "Owned {0}",
   "CardOwnedInDeck_Format": "Owned {0}, In Deck {1}",
-
   "CardPosition_Format": "{0}{1}, {2} of {3}",
-
   "LibraryCount_One": "Library, 1 card",
   "LibraryCount_Format": "Library, {0} cards",
   "OpponentLibraryCount_One": "Opponent's library, 1 card",
@@ -140,13 +123,11 @@
   "LibraryCountNotAvailable": "Library count not available",
   "OpponentLibraryCountNotAvailable": "Opponent's library count not available",
   "OpponentHandCountNotAvailable": "Opponent's hand count not available",
-
   "PlayerInfo": "Player info",
   "You": "You",
   "Opponent": "Opponent",
   "EndOfProperties": "End of properties",
   "PlayerType": "player",
-
   "Life_Format": "{0} life",
   "LifeNotAvailable": "Life not available",
   "TimerNotAvailable": "Timer not available",
@@ -156,11 +137,9 @@
   "GamesWon_Format": "{0} games won",
   "WinsNotAvailable": "Wins not available",
   "RankNotAvailable": "Rank not available",
-
   "Emotes": "Emotes",
   "EmoteSent_Format": "{0} sent",
   "EmotesNotAvailable": "Emotes not available",
-
   "InputFieldEmpty": "empty",
   "InputFieldStart": "start",
   "InputFieldEnd": "end",
@@ -171,7 +150,6 @@
   "InputFieldEmptyWithLabel_Format": "{0}, empty",
   "InputFieldPasswordWithCount_Format": "{0}, {1} characters",
   "InputFieldHint": "Press Enter to edit",
-
   "CharSpace": "space",
   "CharDot": "dot",
   "CharComma": "comma",
@@ -205,7 +183,6 @@
   "CharTilde": "tilde",
   "CharBacktick": "backtick",
   "CharCaret": "caret",
-
   "ManaTap": "Tap",
   "ManaUntap": "Untap",
   "ManaWhite": "White",
@@ -221,7 +198,6 @@
   "ManaPhyrexian": "Phyrexian",
   "ManaPhyrexian_Format": "Phyrexian {0}",
   "ManaHybrid_Format": "{0} or {1}",
-
   "ManaColorPicker_Format": "Choose mana color: {0}",
   "ManaColorPicker_Option_Format": "{0} {1}",
   "ManaColorPicker_Selected_Format": "Selected {0}. Selection {1} of {2}",
@@ -229,7 +205,6 @@
   "ManaColorPicker_Done_Format": "Selected {0}",
   "ManaColorPicker_Cancelled": "Mana color selection cancelled",
   "ManaColorPicker_InvalidKey": "Invalid option",
-
   "SettingsMenuTitle": "Mod Settings",
   "SettingsMenuInstructions": "Arrow Up and Down to navigate, Enter to change, Backspace or F2 to close",
   "SettingsMenuClosed": "Mod settings closed",
@@ -241,12 +216,10 @@
   "SettingOff": "Off",
   "SettingChanged_Format": "{0} set to {1}",
   "SettingItemPosition_Format": "{0} of {1}: {2}",
-
   "HelpMenuTitle": "Help Menu",
   "HelpMenuInstructions": "Arrow Up and Down to navigate, Backspace or F1 to close",
   "HelpItemPosition_Format": "{2}, {0} of {1}",
   "HelpMenuClosed": "Help closed",
-
   "HelpCategoryGlobal": "Global shortcuts",
   "HelpCategoryMenuNavigation": "Menu navigation",
   "HelpCategoryDuelZones": "Zones in duel",
@@ -255,13 +228,11 @@
   "HelpCategoryCardDetails": "Card details",
   "HelpCategoryCombat": "Combat",
   "HelpCategoryBrowser": "Browser (Scry, Surveil, Mulligan)",
-
   "HelpF1Help": "F1: Help menu",
   "HelpF2Settings": "F2: Settings menu",
   "HelpF3Context": "F3: Current screen",
   "HelpCtrlRRepeat": "Control plus R: Repeat last announcement",
   "HelpBackspace": "Backspace: Back, dismiss, or cancel",
-
   "HelpArrowUpDown": "Arrow Up or Down: Navigate menu items",
   "HelpTabNavigation": "Tab or Shift plus Tab: Navigate menu items, or switch groups in collection",
   "HelpArrowLeftRight": "Arrow Left or Right: Carousel and stepper controls",
@@ -269,14 +240,12 @@
   "HelpPageUpDown": "Page Up or Page Down: Previous or next page in collection",
   "HelpNumberKeysFilters": "Number keys 1 to 0: Activate filters 1 to 10 in collection",
   "HelpEnterSpace": "Enter or Space: Activate",
-
   "HelpCategoryInputFields": "Input fields",
   "HelpEnterEditField": "Enter: Start editing text field",
   "HelpEscapeExitField": "Escape: Stop editing, stay on field",
   "HelpTabNextField": "Tab: Stop editing and move to next element",
   "HelpShiftTabPrevField": "Shift plus Tab: Stop editing and move to previous element",
   "HelpArrowsInField": "Arrows in field: Left or Right reads character, Up or Down reads content",
-
   "HelpCHand": "C: Your hand, Shift plus C: Opponent hand count",
   "HelpBBattlefield": "B: Your creatures, Shift plus B: Opponent creatures",
   "HelpALands": "A: Your lands, Shift plus A: Opponent lands",
@@ -285,39 +254,31 @@
   "HelpXExile": "X: Your exile, Shift plus X: Opponent exile",
   "HelpSStack": "S: Stack",
   "HelpDLibrary": "D: Your library, Shift plus D: Opponent library",
-
   "HelpLLifeTotals": "L: Life totals",
   "HelpTTurnPhase": "T: Turn and phase",
   "HelpVPlayerInfo": "V: Player info zone",
   "HelpMLandSummary": "M: Your land summary, Shift plus M: Opponent land summary",
-
   "HelpLeftRightCards": "Left or Right arrow: Previous or next card",
   "HelpHomeEndCards": "Home or End: First or last card",
   "HelpEnterPlay": "Enter: Play or activate card",
   "HelpTabTargets": "Tab: Cycle through targets or playable cards",
-
   "HelpUpDownDetails": "Up or Down arrow: Navigate card details",
-
   "HelpCategoryDuelGeneral": "General duel commands",
   "HelpSpaceAdvance": "Space: Confirm or advance phase",
   "HelpBackspaceCancel": "Backspace: Cancel",
   "HelpEnterSelect": "Enter: Select",
   "HelpYUndo": "Y: Undo",
   "HelpQQFloatMana": "Double press Q: Tap all lands for mana",
-
   "HelpSpaceCombat": "Space: Confirm attackers or blockers",
   "HelpBackspaceCombat": "Backspace: No attacks or cancel blocks",
-
   "HelpTabBrowser": "Tab: Navigate all cards",
   "HelpCDZones": "C or D: Jump to keep or bottom zone",
   "HelpEnterToggle": "Enter: Toggle card between zones",
   "HelpSpaceConfirm": "Space: Confirm selection",
-
   "HelpCategoryDebug": "Debug keys (developers)",
   "HelpF4Refresh": "F4: Refresh current navigator",
   "HelpF11CardDump": "F11: Dump card details to log (pack opening)",
   "HelpF12UIDump": "F12: Dump UI hierarchy to log",
-
   "NoCards": "No cards",
   "NoButtonSelected": "No button selected",
   "NoButtonsAvailable": "No buttons available",
@@ -336,7 +297,6 @@
   "BrowserCards_One": "{0}. 1 card. Tab to navigate, Enter to select",
   "BrowserOptions_Format": "{0}. Tab to navigate options",
   "ZoneChange": "Zone",
-
   "MasteryActivation_Format": "{0}. Level {1} of {2}, {3}. Arrow keys to navigate levels.",
   "MasteryLevel_Format": "Level {0}: {1}",
   "MasteryLevelWithStatus_Format": "Level {0}: {1}. {2}",
@@ -355,18 +315,15 @@
   "MasteryStatus": "Status",
   "MasteryStatusInfo_Format": "Level {0} of {1}",
   "MasteryStatusInfoWithXP_Format": "Level {0} of {1}, {2}",
-
   "PrizeWallActivation_Format": "Prize Wall. {0} items. {1} spheres available. Arrow keys to navigate.",
   "PrizeWallItem_Format": "{0} of {1}: {2}",
   "PrizeWallSphereStatus_Format": "{0} spheres available",
   "PopupCancel": "Cancel",
-
   "NavigateHint": "Arrow keys to navigate, Enter to select",
   "DuelKeybindingsHint": "Tab cycles playable cards. C for hand. B for your creatures, A for your lands, R for your non-creatures. Shift plus B, A, R for enemy. G for graveyard, X for exile, S for stack. V for player info. P for full control, Shift plus P to lock. Number keys 1 to 0 for phase stops",
   "ItemsCount_One": "1 item",
   "ItemsCount_Format": "{0} items",
   "ActivationWithItems_Format": "{0}. {1}. {2}",
-
   "SearchResults_Format": "Search results: {0} cards",
   "SearchResultsItems_Format": "Search results: {0} items",
   "ExitedEditMode": "Exited edit mode",
@@ -432,7 +389,6 @@
   "PackDetailsDumped": "Pack details dumped to log.",
   "WaitingForPlayable": "Waiting for playable cards...",
   "NoSearchResults": "No search results",
-
   "BrowserHint": "Tab to see card, Enter to keep on top",
   "EnterToSelect": "Enter to select",
   "TabToNavigate": "Tab to navigate",
@@ -440,7 +396,6 @@
   "HasCharacters_Format": "has {0} characters",
   "PositionOf_Format": "{0} of {1}",
   "LabelValue_Format": "{0}: {1}",
-
   "GroupPrimaryActions": "Primary Actions",
   "GroupPlay": "Play",
   "GroupProgress": "Progress",
@@ -487,7 +442,6 @@
   "ChallengeBlockOpponent": "Block opponent",
   "ChallengeAddFriend": "Add friend",
   "GroupOther": "Other",
-
   "NoItemsFound": "No items found.",
   "NoNavigableItemsFound": "No navigable items found.",
   "GroupCount_Format": "{0} groups",
@@ -498,7 +452,6 @@
   "ScreenGroupsSummary_Format": "{0}. {2}. {1}",
   "ScreenItemsSummary_Format": "{0}. {2}. {1}",
   "ObjectivesEntry_Format": "Objectives, {0}",
-
   "LangEnglish": "English",
   "LangGerman": "German",
   "LangFrench": "French",
@@ -511,7 +464,6 @@
   "LangPolish": "Polish",
   "LangChineseSimplified": "Chinese Simplified",
   "LangChineseTraditional": "Chinese Traditional",
-
   "ScreenHome": "Home",
   "ScreenDecks": "Decks",
   "ScreenProfile": "Profile",
@@ -577,7 +529,6 @@
   "ScreenRewardPopup": "Reward popup",
   "ScreenOverlay": "Overlay",
   "WaitingForServer": "Waiting for server",
-
   "Zone_Hand": "Your hand",
   "Zone_Battlefield": "Battlefield",
   "Zone_Graveyard": "Your graveyard",
@@ -590,14 +541,12 @@
   "Zone_OpponentLibrary": "Opponent's library",
   "Zone_OpponentExile": "Opponent's exile",
   "Zone_OpponentCommand": "Opponent's command zone",
-
   "Row_PlayerCreatures": "Your creatures",
   "Row_PlayerNonCreatures": "Your non-creatures",
   "Row_PlayerLands": "Your lands",
   "Row_EnemyCreatures": "Enemy creatures",
   "Row_EnemyNonCreatures": "Enemy non-creatures",
   "Row_EnemyLands": "Enemy lands",
-
   "BrowserZone_KeepOnTop": "Keep on top",
   "BrowserZone_PutOnBottom": "Put on bottom",
   "BrowserZone_KeepPile": "Keep pile",
@@ -608,7 +557,6 @@
   "BrowserZone_Entry_Format": "{0}: {1} cards. {2}, 1 of {3}",
   "BrowserZone_Card_Format": "{0}, {1}, {2} of {3}",
   "BrowserZone_NoCardSelected": "No card selected",
-
   "Browser_Scry": "Scry",
   "Browser_Surveil": "Surveil",
   "Browser_ReadAhead": "Read ahead",
@@ -631,12 +579,10 @@
   "Browser_Information": "Information",
   "Browser_ChooseAction": "Choose action",
   "Browser_Default": "Browser",
-
   "DamageAssign_Entry_Format": "Assign damage. {0}, {1} damage. {2} blockers",
   "DamageAssign_Entry_One_Format": "Assign damage. {0}, {1} damage. 1 blocker",
   "DamageAssign_Assigned_Format": "{0} of {1} assigned",
   "DamageAssign_Lethal": "lethal",
-
   "Combat_Attacking": "attacking",
   "Combat_CanAttack": "can attack",
   "Combat_Blocking_Format": "blocking {0}",
@@ -647,10 +593,8 @@
   "Combat_Tapped": "tapped",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "assigned",
-
   "Target_Targeted_Format": "Targeted {0}",
   "Target_Selected_Format": "Selected {0}",
-
   "Card_EnchantedBy_One_Format": "enchanted by {0}",
   "Card_EnchantedBy_Many_Format": "enchanted by {0}",
   "Card_AttachedTo_Format": "attached to {0}",
@@ -660,9 +604,7 @@
   "Card_TargetedBy_One_Format": "targeted by {0}",
   "Card_TargetedBy_Two_Format": "targeted by {0} and {1}",
   "Card_TargetedBy_Many_Format": "targeted by {0}",
-
   "Duel_Started_Format": "Duel started. {0} cards in hand",
-
   "Duel_YourTurn_Format": "Turn {0}",
   "Duel_OpponentTurn": "Opponent's turn",
   "Duel_TurnChanged": "Turn changed",
@@ -678,7 +620,6 @@
   "Duel_CardToYourGraveyard": "Card went to your graveyard",
   "Duel_CardToOpponentGraveyard": "Card went to opponent's graveyard",
   "Duel_SpellResolved": "Spell resolved",
-
   "Duel_Phase_FirstMain": "First main phase",
   "Duel_Phase_SecondMain": "Second main phase",
   "Duel_Phase_DeclareAttackers": "Declare attackers",
@@ -689,7 +630,6 @@
   "Duel_Phase_Upkeep": "Upkeep",
   "Duel_Phase_Draw": "Draw",
   "Duel_Phase_EndStep": "End step",
-
   "Duel_PhaseDesc_FirstMain": "first main phase",
   "Duel_PhaseDesc_SecondMain": "second main phase",
   "Duel_PhaseDesc_DeclareAttackers": "declare attackers",
@@ -703,35 +643,29 @@
   "Duel_PhaseDesc_Beginning": "beginning phase",
   "Duel_PhaseDesc_Ending": "ending phase",
   "Duel_PhaseDesc_Turn": "turn",
-
   "Duel_TurnPhase_Format": "{0} {1}, turn {2}",
   "Duel_TurnPhaseNoCount_Format": "{0} {1}",
   "Duel_Your": "Your",
   "Duel_Opponents": "Opponent's",
   "Duel_You": "You",
   "Duel_Opponent": "Opponent",
-
   "Duel_LifeGained_Format": "{0} gained {1} life",
   "Duel_LifeLost_Format": "{0} lost {1} life",
-
   "Duel_DamageDeals_Format": "{0} deals {1} to {2}",
   "Duel_DamageAmount_Format": "{0} to {1}",
   "Duel_DamageToYou": "you",
   "Duel_DamageToOpponent": "opponent",
   "Duel_DamageTarget": "target",
   "Duel_CombatDamageSource": "Combat damage",
-
   "Duel_Revealed_Format": "Revealed {0}",
   "Duel_CounterGained_Format": "{0} gained {1} {2} counter",
   "Duel_CounterGainedPlural_Format": "{0} gained {1} {2} counters",
   "Duel_CounterLost_Format": "{0} lost {1} {2} counter",
   "Duel_CounterLostPlural_Format": "{0} lost {1} {2} counters",
   "Duel_CounterCreature": "creature",
-
   "Duel_Victory": "Victory!",
   "Duel_Defeat": "Defeat",
   "Duel_GameEnded": "Game ended",
-
   "Duel_CombatBegins": "Combat begins",
   "Duel_AttackerDeclared": "Attacker declared",
   "Duel_OpponentAttackerDeclared": "Opponent's attacker declared",
@@ -740,7 +674,6 @@
   "Duel_AttackerRemoved": "Attacker removed",
   "Duel_Attackers_One": "1 attacker",
   "Duel_Attackers_Format": "{0} attackers",
-
   "Duel_TokenCreated_Format": "{0} token created",
   "Duel_Played_Format": "{0} played {1}",
   "Duel_Enchanted_Format": "{0} enchanted {1}",
@@ -751,7 +684,6 @@
   "Duel_ReturnedFromExileEnchanting_Format": "{0} returned from exile, enchanting {1}",
   "Duel_EntersBattlefieldFromLibrary_Format": "{0} enters battlefield from library",
   "Duel_EntersBattlefieldFromLibraryEnchanting_Format": "{0} enters battlefield from library, enchanting {1}",
-
   "Duel_Died_Format": "{0}{1} died",
   "Duel_Destroyed_Format": "{0}{1} was destroyed",
   "Duel_Sacrificed_Format": "{0}{1} was sacrificed",
@@ -759,32 +691,25 @@
   "Duel_Discarded_Format": "{0}{1} was discarded",
   "Duel_Milled_Format": "{0}{1} was milled",
   "Duel_WentToGraveyard_Format": "{0}{1} went to graveyard",
-
   "Duel_Exiled_Format": "{0}{1} was exiled",
   "Duel_ExiledFromGraveyard_Format": "{0}{1} was exiled from graveyard",
   "Duel_ExiledFromHand_Format": "{0}{1} was exiled from hand",
   "Duel_ExiledFromLibrary_Format": "{0}{1} was exiled from library",
   "Duel_CounteredAndExiled_Format": "{0}{1} was countered and exiled",
-
   "Duel_ReturnedToHand_Format": "{0}{1} returned to hand",
   "Duel_ReturnedToHandFromGraveyard_Format": "{0}{1} returned to hand from graveyard",
   "Duel_ReturnedToHandFromExile_Format": "{0}{1} returned to hand from exile",
-
   "Duel_DamageTo_Format": "{0} deals {1} to {2}",
   "Duel_DamageAmountTo_Format": "{0} damage to {1}",
   "Duel_CreatureDamage_Format": "{0} deals {1} to {2}",
-
   "Duel_ScryHint": "Scry. Tab to see card, Enter to keep on top, Space to put on bottom",
   "Duel_SurveilHint": "Surveil. Tab to see card, Enter to keep on top, Space to put in graveyard",
   "Duel_EffectHint_Format": "{0}. Tab to navigate, Enter to select",
   "Duel_LookAtTopCard": "Look at top card",
-
   "Duel_SelectForBottom_One": "Select 1 card to put on bottom. {0} cards. Enter to toggle, Space when done",
   "Duel_SelectForBottom_Format": "Select {0} cards to put on bottom. {1} cards. Enter to toggle, Space when done",
   "Duel_SelectedForBottom_Format": "{0} of {1} selected for bottom",
-
   "Duel_OwnerPrefix_Opponent": "Opponent's ",
-
   "CardInfoKeywords": "Keywords",
   "NoExtendedCardInfo": "No additional information",
   "LinkedFace_OtherFace": "Other face",
@@ -792,13 +717,10 @@
   "LinkedFace_Adventure": "Adventure",
   "LinkedFace_OtherRoom": "Other room",
   "HelpIExtendedInfo": "I: Extended card info (keywords and other faces)",
-
   "ExtendedInfoTitle": "Extended card info",
   "ExtendedInfoClosed": "Extended info closed",
   "ExtendedInfoInstructions": "Navigate with Up and Down. Close with I or Backspace.",
-
   "Bo3Toggle": "Best of 3",
-
   "FriendActionChat": "Chat",
   "FriendActionChallenge": "Challenge",
   "FriendActionUnfriend": "Unfriend",
@@ -807,7 +729,6 @@
   "FriendActionDecline": "Decline",
   "FriendActionRevoke": "Revoke",
   "FriendActionUnblock": "Unblock",
-
   "ScreenPacketSelect": "Packet Selection",
   "EventTileRanked": "Ranked",
   "EventTileBo3": "Best of 3",
@@ -817,14 +738,21 @@
   "EventScreenTitle_Format": "Event: {0}",
   "PacketOf_Format": "Packet {0} of {1}",
   "EventInfoLabel": "Info",
-
+  "ColorChallengeProgress_Format": "{0}: {1} of {2} nodes unlocked",
+  "ColorChallengeTrackComplete_Format": "{0}: track complete",
+  "ColorChallengeComplete": "Track complete",
+  "ColorChallengeProgressNoTrack_Format": "{0} of {1} nodes unlocked",
+  "ColorChallengeNode_Format": "Challenge {0}",
+  "ColorChallengeNodeCompleted": "Completed",
+  "ColorChallengeNodeCurrent": "Current",
+  "ColorChallengeNodeLocked": "Locked",
+  "ColorChallengeNodeAvailable": "Available",
   "FullControl_On": "Full control on",
   "FullControl_Off": "Full control off",
   "FullControl_Locked": "Full control locked",
   "FullControl_Unlocked": "Full control unlocked",
   "PhaseStop_Set_Format": "Stop set: {0}",
   "PhaseStop_Cleared_Format": "Stop cleared: {0}",
-
   "PhaseStop_Upkeep": "Upkeep",
   "PhaseStop_Draw": "Draw",
   "PhaseStop_FirstMain": "First main",
@@ -835,16 +763,12 @@
   "PhaseStop_EndCombat": "End combat",
   "PhaseStop_SecondMain": "Second main",
   "PhaseStop_EndStep": "End step",
-
   "HelpPFullControl": "P: Full control, Shift plus P: Lock full control",
   "HelpNumberPhaseStops": "1 to 0: Toggle phase stops (upkeep through end step)",
-
   "CurrencyGold": "Gold",
   "CurrencyGems": "Gems",
   "CurrencyWildcards": "Wildcards",
-
   "NumberWords": "a=1,an=1,one=1,two=2,three=3,four=4,five=5,six=6,seven=7,eight=8,nine=9,ten=10",
-
   "RoleButton": "button",
   "RoleLink": "link",
   "RoleCheckbox": "checkbox",
@@ -870,28 +794,27 @@
   "CodexCollapsed_Format": "{0}, collapsed",
   "CodexSection": "section",
   "CodexNoContent": "No content available",
-
   "Duel_NoCounters": "No counters",
   "Duel_CounterEntry_Format": "{0} {1} counter",
   "Duel_CounterEntryPlural_Format": "{0} {1} counters",
   "Duel_Loyalty_Format": "Loyalty {0}",
-
   "HelpKCounters": "K: Counter info on focused card",
-
   "StoreSetFilter_Position_Format": "{0}, {1} of {2} sets",
   "StoreSetFilter_Items_Format": "{0}. {1} items.",
   "StoreSetFilter_Items_One": "{0}. 1 item.",
   "StoreSetFilter_EnterItems_Format": "Packs: {0}. {1} items.",
   "StoreSetFilter_EnterItems_One": "Packs: {0}. 1 item.",
-
   "ChooseX_Entry_Format": "Choose value. Current: {0}. Up/Down to adjust, Enter to confirm, Backspace to cancel",
   "ChooseX_Confirmed_Format": "Confirmed: {0}",
   "ChooseX_Cancelled": "Selection cancelled",
   "ChooseX_AtMax": "Maximum reached",
   "ChooseX_AtMin": "Minimum reached",
   "ChooseX_CannotSubmit": "Cannot submit current value",
-
   "KeywordSelection_Entry_Format": "Choose keyword. {0} options. Tab to navigate, Enter to select, Space to confirm",
   "KeywordSelection_Selected": "selected",
-  "KeywordSelection_Toggled_Format": "{0}, {1}"
+  "KeywordSelection_Toggled_Format": "{0}, {1}",
+  "ColorChallengeMatchPvP": "PvP Match",
+  "ColorChallengeMatchAI": "AI Match",
+  "ColorChallengeDeckUpgrade": "Deck Upgrade",
+  "ColorChallengeReward_Format": "Reward: {0}"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -738,6 +738,15 @@
   "EventScreenTitle_Format": "Evento: {0}",
   "PacketOf_Format": "Paquete {0} de {1}",
   "EventInfoLabel": "Info",
+  "ColorChallengeProgress_Format": "{0}: {1} of {2} nodes unlocked",
+  "ColorChallengeTrackComplete_Format": "{0}: track complete",
+  "ColorChallengeComplete": "Track complete",
+  "ColorChallengeProgressNoTrack_Format": "{0} of {1} nodes unlocked",
+  "ColorChallengeNode_Format": "Challenge {0}",
+  "ColorChallengeNodeCompleted": "Completed",
+  "ColorChallengeNodeCurrent": "Current",
+  "ColorChallengeNodeLocked": "Locked",
+  "ColorChallengeNodeAvailable": "Available",
   "FullControl_On": "Control total activado",
   "FullControl_Off": "Control total desactivado",
   "FullControl_Locked": "Control total bloqueado",
@@ -803,5 +812,9 @@
   "ChooseX_CannotSubmit": "No se puede enviar el valor actual",
   "KeywordSelection_Entry_Format": "Elegir palabra clave. {0} opciones. Tab para navegar, Enter para seleccionar, Espacio para confirmar",
   "KeywordSelection_Selected": "seleccionado",
-  "KeywordSelection_Toggled_Format": "{0}, {1}"
+  "KeywordSelection_Toggled_Format": "{0}, {1}",
+  "ColorChallengeMatchPvP": "PvP Match",
+  "ColorChallengeMatchAI": "AI Match",
+  "ColorChallengeDeckUpgrade": "Deck Upgrade",
+  "ColorChallengeReward_Format": "Reward: {0}"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -738,6 +738,15 @@
   "EventScreenTitle_Format": "Événement : {0}",
   "PacketOf_Format": "Paquet {0} sur {1}",
   "EventInfoLabel": "Info",
+  "ColorChallengeProgress_Format": "{0}: {1} of {2} nodes unlocked",
+  "ColorChallengeTrackComplete_Format": "{0}: track complete",
+  "ColorChallengeComplete": "Track complete",
+  "ColorChallengeProgressNoTrack_Format": "{0} of {1} nodes unlocked",
+  "ColorChallengeNode_Format": "Challenge {0}",
+  "ColorChallengeNodeCompleted": "Completed",
+  "ColorChallengeNodeCurrent": "Current",
+  "ColorChallengeNodeLocked": "Locked",
+  "ColorChallengeNodeAvailable": "Available",
   "FullControl_On": "ContrÃ´le total activÃ©",
   "FullControl_Off": "ContrÃ´le total dÃ©sactivÃ©",
   "FullControl_Locked": "ContrÃ´le total verrouillÃ©",
@@ -803,5 +812,9 @@
   "ChooseX_CannotSubmit": "Impossible d'envoyer la valeur actuelle",
   "KeywordSelection_Entry_Format": "Choisir un mot-clé. {0} options. Tab pour naviguer, Entrée pour sélectionner, Espace pour confirmer",
   "KeywordSelection_Selected": "sélectionné",
-  "KeywordSelection_Toggled_Format": "{0}, {1}"
+  "KeywordSelection_Toggled_Format": "{0}, {1}",
+  "ColorChallengeMatchPvP": "PvP Match",
+  "ColorChallengeMatchAI": "AI Match",
+  "ColorChallengeDeckUpgrade": "Deck Upgrade",
+  "ColorChallengeReward_Format": "Reward: {0}"
 }

--- a/lang/it.json
+++ b/lang/it.json
@@ -738,6 +738,15 @@
   "EventScreenTitle_Format": "Evento: {0}",
   "PacketOf_Format": "Pacchetto {0} di {1}",
   "EventInfoLabel": "Info",
+  "ColorChallengeProgress_Format": "{0}: {1} of {2} nodes unlocked",
+  "ColorChallengeTrackComplete_Format": "{0}: track complete",
+  "ColorChallengeComplete": "Track complete",
+  "ColorChallengeProgressNoTrack_Format": "{0} of {1} nodes unlocked",
+  "ColorChallengeNode_Format": "Challenge {0}",
+  "ColorChallengeNodeCompleted": "Completed",
+  "ColorChallengeNodeCurrent": "Current",
+  "ColorChallengeNodeLocked": "Locked",
+  "ColorChallengeNodeAvailable": "Available",
   "FullControl_On": "Controllo totale attivato",
   "FullControl_Off": "Controllo totale disattivato",
   "FullControl_Locked": "Controllo totale bloccato",
@@ -803,5 +812,9 @@
   "ChooseX_CannotSubmit": "Impossibile inviare il valore attuale",
   "KeywordSelection_Entry_Format": "Scegli parola chiave. {0} opzioni. Tab per navigare, Invio per selezionare, Spazio per confermare",
   "KeywordSelection_Selected": "selezionato",
-  "KeywordSelection_Toggled_Format": "{0}, {1}"
+  "KeywordSelection_Toggled_Format": "{0}, {1}",
+  "ColorChallengeMatchPvP": "PvP Match",
+  "ColorChallengeMatchAI": "AI Match",
+  "ColorChallengeDeckUpgrade": "Deck Upgrade",
+  "ColorChallengeReward_Format": "Reward: {0}"
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -738,6 +738,15 @@
   "EventScreenTitle_Format": "イベント: {0}",
   "PacketOf_Format": "パケット{0}/{1}",
   "EventInfoLabel": "情報",
+  "ColorChallengeProgress_Format": "{0}: {1} of {2} nodes unlocked",
+  "ColorChallengeTrackComplete_Format": "{0}: track complete",
+  "ColorChallengeComplete": "Track complete",
+  "ColorChallengeProgressNoTrack_Format": "{0} of {1} nodes unlocked",
+  "ColorChallengeNode_Format": "Challenge {0}",
+  "ColorChallengeNodeCompleted": "Completed",
+  "ColorChallengeNodeCurrent": "Current",
+  "ColorChallengeNodeLocked": "Locked",
+  "ColorChallengeNodeAvailable": "Available",
   "FullControl_On": "フルコントロール オン",
   "FullControl_Off": "フルコントロール オフ",
   "FullControl_Locked": "フルコントロール ロック",
@@ -803,5 +812,9 @@
   "ChooseX_CannotSubmit": "現在の値を送信できません",
   "KeywordSelection_Entry_Format": "キーワードを選択。{0}個の選択肢。Tabで移動、Enterで選択、Spaceで確定",
   "KeywordSelection_Selected": "選択済み",
-  "KeywordSelection_Toggled_Format": "{0}、{1}"
+  "KeywordSelection_Toggled_Format": "{0}、{1}",
+  "ColorChallengeMatchPvP": "PvP Match",
+  "ColorChallengeMatchAI": "AI Match",
+  "ColorChallengeDeckUpgrade": "Deck Upgrade",
+  "ColorChallengeReward_Format": "Reward: {0}"
 }

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -738,6 +738,15 @@
   "EventScreenTitle_Format": "이벤트: {0}",
   "PacketOf_Format": "패킷 {0}/{1}",
   "EventInfoLabel": "정보",
+  "ColorChallengeProgress_Format": "{0}: {1} of {2} nodes unlocked",
+  "ColorChallengeTrackComplete_Format": "{0}: track complete",
+  "ColorChallengeComplete": "Track complete",
+  "ColorChallengeProgressNoTrack_Format": "{0} of {1} nodes unlocked",
+  "ColorChallengeNode_Format": "Challenge {0}",
+  "ColorChallengeNodeCompleted": "Completed",
+  "ColorChallengeNodeCurrent": "Current",
+  "ColorChallengeNodeLocked": "Locked",
+  "ColorChallengeNodeAvailable": "Available",
   "FullControl_On": "풀 컨트롤 켜짐",
   "FullControl_Off": "풀 컨트롤 꺼짐",
   "FullControl_Locked": "풀 컨트롤 잠금",
@@ -803,5 +812,9 @@
   "ChooseX_CannotSubmit": "현재 값을 제출할 수 없습니다",
   "KeywordSelection_Entry_Format": "키워드 선택. {0}개 옵션. Tab으로 이동, Enter로 선택, Space로 확인",
   "KeywordSelection_Selected": "선택됨",
-  "KeywordSelection_Toggled_Format": "{0}, {1}"
+  "KeywordSelection_Toggled_Format": "{0}, {1}",
+  "ColorChallengeMatchPvP": "PvP Match",
+  "ColorChallengeMatchAI": "AI Match",
+  "ColorChallengeDeckUpgrade": "Deck Upgrade",
+  "ColorChallengeReward_Format": "Reward: {0}"
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -738,6 +738,15 @@
   "EventScreenTitle_Format": "Wydarzenie: {0}",
   "PacketOf_Format": "Pakiet {0} z {1}",
   "EventInfoLabel": "Info",
+  "ColorChallengeProgress_Format": "{0}: {1} of {2} nodes unlocked",
+  "ColorChallengeTrackComplete_Format": "{0}: track complete",
+  "ColorChallengeComplete": "Track complete",
+  "ColorChallengeProgressNoTrack_Format": "{0} of {1} nodes unlocked",
+  "ColorChallengeNode_Format": "Challenge {0}",
+  "ColorChallengeNodeCompleted": "Completed",
+  "ColorChallengeNodeCurrent": "Current",
+  "ColorChallengeNodeLocked": "Locked",
+  "ColorChallengeNodeAvailable": "Available",
   "FullControl_On": "Pełna kontrola włączona",
   "FullControl_Off": "Pełna kontrola wyłączona",
   "FullControl_Locked": "Pełna kontrola zablokowana",
@@ -816,5 +825,9 @@
   "InputFieldCharacterCount_Few": "{0} znaki",
   "BrowserCards_Few": "{0}. {1} karty. Tab do nawigacji, Enter do wyboru",
   "ItemsCount_Few": "{0} przedmioty",
-  "ItemCount_Few": "{0} elementy"
+  "ItemCount_Few": "{0} elementy",
+  "ColorChallengeMatchPvP": "PvP Match",
+  "ColorChallengeMatchAI": "AI Match",
+  "ColorChallengeDeckUpgrade": "Deck Upgrade",
+  "ColorChallengeReward_Format": "Reward: {0}"
 }

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -738,6 +738,15 @@
   "EventScreenTitle_Format": "Evento: {0}",
   "PacketOf_Format": "Pacote {0} de {1}",
   "EventInfoLabel": "Info",
+  "ColorChallengeProgress_Format": "{0}: {1} of {2} nodes unlocked",
+  "ColorChallengeTrackComplete_Format": "{0}: track complete",
+  "ColorChallengeComplete": "Track complete",
+  "ColorChallengeProgressNoTrack_Format": "{0} of {1} nodes unlocked",
+  "ColorChallengeNode_Format": "Challenge {0}",
+  "ColorChallengeNodeCompleted": "Completed",
+  "ColorChallengeNodeCurrent": "Current",
+  "ColorChallengeNodeLocked": "Locked",
+  "ColorChallengeNodeAvailable": "Available",
   "FullControl_On": "Controle total ativado",
   "FullControl_Off": "Controle total desativado",
   "FullControl_Locked": "Controle total travado",
@@ -803,5 +812,9 @@
   "ChooseX_CannotSubmit": "Não é possível enviar o valor atual",
   "KeywordSelection_Entry_Format": "Escolher palavra-chave. {0} opções. Tab para navegar, Enter para selecionar, Espaço para confirmar",
   "KeywordSelection_Selected": "selecionado",
-  "KeywordSelection_Toggled_Format": "{0}, {1}"
+  "KeywordSelection_Toggled_Format": "{0}, {1}",
+  "ColorChallengeMatchPvP": "PvP Match",
+  "ColorChallengeMatchAI": "AI Match",
+  "ColorChallengeDeckUpgrade": "Deck Upgrade",
+  "ColorChallengeReward_Format": "Reward: {0}"
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -738,6 +738,15 @@
   "EventScreenTitle_Format": "Событие: {0}",
   "PacketOf_Format": "Пакет {0} из {1}",
   "EventInfoLabel": "Инфо",
+  "ColorChallengeProgress_Format": "{0}: {1} of {2} nodes unlocked",
+  "ColorChallengeTrackComplete_Format": "{0}: track complete",
+  "ColorChallengeComplete": "Track complete",
+  "ColorChallengeProgressNoTrack_Format": "{0} of {1} nodes unlocked",
+  "ColorChallengeNode_Format": "Challenge {0}",
+  "ColorChallengeNodeCompleted": "Completed",
+  "ColorChallengeNodeCurrent": "Current",
+  "ColorChallengeNodeLocked": "Locked",
+  "ColorChallengeNodeAvailable": "Available",
   "FullControl_On": "Полный контроль включён",
   "FullControl_Off": "Полный контроль выключен",
   "FullControl_Locked": "Полный контроль заблокирован",
@@ -816,5 +825,9 @@
   "InputFieldCharacterCount_Few": "{0} символа",
   "BrowserCards_Few": "{0}. {1} карты. Tab для навигации, Enter для выбора",
   "ItemsCount_Few": "{0} предмета",
-  "ItemCount_Few": "{0} элемента"
+  "ItemCount_Few": "{0} элемента",
+  "ColorChallengeMatchPvP": "PvP Match",
+  "ColorChallengeMatchAI": "AI Match",
+  "ColorChallengeDeckUpgrade": "Deck Upgrade",
+  "ColorChallengeReward_Format": "Reward: {0}"
 }

--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -738,6 +738,15 @@
   "EventScreenTitle_Format": "赛事：{0}",
   "PacketOf_Format": "包 {0}/{1}",
   "EventInfoLabel": "信息",
+  "ColorChallengeProgress_Format": "{0}: {1} of {2} nodes unlocked",
+  "ColorChallengeTrackComplete_Format": "{0}: track complete",
+  "ColorChallengeComplete": "Track complete",
+  "ColorChallengeProgressNoTrack_Format": "{0} of {1} nodes unlocked",
+  "ColorChallengeNode_Format": "Challenge {0}",
+  "ColorChallengeNodeCompleted": "Completed",
+  "ColorChallengeNodeCurrent": "Current",
+  "ColorChallengeNodeLocked": "Locked",
+  "ColorChallengeNodeAvailable": "Available",
   "FullControl_On": "完全控制 开启",
   "FullControl_Off": "完全控制 关闭",
   "FullControl_Locked": "完全控制 已锁定",
@@ -803,5 +812,9 @@
   "ChooseX_CannotSubmit": "无法提交当前值",
   "KeywordSelection_Entry_Format": "选择关键词。{0}个选项。Tab导航，Enter选择，Space确认",
   "KeywordSelection_Selected": "已选择",
-  "KeywordSelection_Toggled_Format": "{0}，{1}"
+  "KeywordSelection_Toggled_Format": "{0}，{1}",
+  "ColorChallengeMatchPvP": "PvP Match",
+  "ColorChallengeMatchAI": "AI Match",
+  "ColorChallengeDeckUpgrade": "Deck Upgrade",
+  "ColorChallengeReward_Format": "Reward: {0}"
 }

--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -738,6 +738,15 @@
   "EventScreenTitle_Format": "賽事：{0}",
   "PacketOf_Format": "包 {0}/{1}",
   "EventInfoLabel": "資訊",
+  "ColorChallengeProgress_Format": "{0}: {1} of {2} nodes unlocked",
+  "ColorChallengeTrackComplete_Format": "{0}: track complete",
+  "ColorChallengeComplete": "Track complete",
+  "ColorChallengeProgressNoTrack_Format": "{0} of {1} nodes unlocked",
+  "ColorChallengeNode_Format": "Challenge {0}",
+  "ColorChallengeNodeCompleted": "Completed",
+  "ColorChallengeNodeCurrent": "Current",
+  "ColorChallengeNodeLocked": "Locked",
+  "ColorChallengeNodeAvailable": "Available",
   "FullControl_On": "完全控制 開啟",
   "FullControl_Off": "完全控制 關閉",
   "FullControl_Locked": "完全控制 已鎖定",
@@ -803,5 +812,9 @@
   "ChooseX_CannotSubmit": "無法提交目前值",
   "KeywordSelection_Entry_Format": "選擇關鍵字。{0}個選項。Tab導覽，Enter選取，Space確認",
   "KeywordSelection_Selected": "已選取",
-  "KeywordSelection_Toggled_Format": "{0}，{1}"
+  "KeywordSelection_Toggled_Format": "{0}，{1}",
+  "ColorChallengeMatchPvP": "PvP Match",
+  "ColorChallengeMatchAI": "AI Match",
+  "ColorChallengeDeckUpgrade": "Deck Upgrade",
+  "ColorChallengeReward_Format": "Reward: {0}"
 }

--- a/src/Core/Models/Strings.cs
+++ b/src/Core/Models/Strings.cs
@@ -1130,6 +1130,25 @@ namespace AccessibleArena.Core.Models
         public static string EventScreenTitle(string eventName) => L.Format("EventScreenTitle_Format", eventName);
         public static string PacketOf(int current, int total) => L.Format("PacketOf_Format", current, total);
         public static string EventInfoLabel => L.Get("EventInfoLabel");
+        public static string ColorChallengeProgress(string trackName, int unlocked, int total, bool completed)
+        {
+            bool hasTrack = !string.IsNullOrEmpty(trackName);
+            if (completed)
+                return hasTrack ? L.Format("ColorChallengeTrackComplete_Format", trackName) : L.Get("ColorChallengeComplete");
+            if (total > 0)
+                return hasTrack ? L.Format("ColorChallengeProgress_Format", trackName, unlocked, total) : L.Format("ColorChallengeProgressNoTrack_Format", unlocked, total);
+            return hasTrack ? trackName : null;
+        }
+        public static string ColorChallengeNode(string roman) => L.Format("ColorChallengeNode_Format", roman);
+        public static string ColorChallengeNodeCompleted => L.Get("ColorChallengeNodeCompleted");
+        public static string ColorChallengeNodeCurrent => L.Get("ColorChallengeNodeCurrent");
+        public static string ColorChallengeNodeLocked => L.Get("ColorChallengeNodeLocked");
+        public static string ColorChallengeNodeAvailable => L.Get("ColorChallengeNodeAvailable");
+        public static string ColorChallengeMatchPvP => L.Get("ColorChallengeMatchPvP");
+        public static string ColorChallengeMatchAI => L.Get("ColorChallengeMatchAI");
+        public static string ColorChallengeDeckUpgrade => L.Get("ColorChallengeDeckUpgrade");
+        public static string ColorChallengeReward(string reward)
+            => L.Format("ColorChallengeReward_Format", reward);
 
         // ===========================================
         // FULL CONTROL & PHASE STOPS

--- a/src/Core/Services/EventAccessor.cs
+++ b/src/Core/Services/EventAccessor.cs
@@ -44,9 +44,14 @@ namespace AccessibleArena.Core.Services
         private static bool _jumpStartReflectionInit;
         private static FieldInfo _packTitleField;           // _packTitle (Localize)
 
+        // --- CampaignGraphContentController reflection cache ---
+        private static bool _campaignGraphReflectionInit;
+        private static FieldInfo _campaignGraphStrategyField;   // _strategy (IColorChallengeStrategy)
+
         // Cached component references (invalidated on scene change)
         private static MonoBehaviour _cachedEventPageController;
         private static MonoBehaviour _cachedPacketController;
+        private static MonoBehaviour _cachedCampaignGraphController;
 
         #region Event Tile Enrichment
 
@@ -957,6 +962,428 @@ namespace AccessibleArena.Core.Services
 
         #endregion
 
+        #region Color Challenge
+
+        /// <summary>
+        /// Get info blocks for the Color Challenge screen by reading the objective
+        /// bubbles that the game renders in CampaignGraphTrackModule.
+        /// Each bubble is a challenge node (I, II, III...) with a status (completed,
+        /// next to unlock, locked) and optional reward popup text.
+        /// </summary>
+        public static System.Collections.Generic.List<CardInfoBlock> GetCampaignGraphInfoBlocks()
+        {
+            var blocks = new System.Collections.Generic.List<CardInfoBlock>();
+
+            try
+            {
+                var controller = FindCampaignGraphController();
+                if (controller == null) return blocks;
+
+                // Find CampaignGraphTrackModule in children
+                MonoBehaviour trackModule = null;
+                foreach (var mb in controller.GetComponentsInChildren<MonoBehaviour>(false))
+                {
+                    if (mb != null && mb.GetType().Name == "CampaignGraphTrackModule")
+                    {
+                        trackModule = mb;
+                        break;
+                    }
+                }
+
+                if (trackModule == null)
+                {
+                    // Track module hidden (not in playing mode yet) — read from strategy data instead
+                    return GetCampaignGraphInfoFromStrategy();
+                }
+
+                // Build node dictionary from strategy data for enrichment
+                var nodeMap = BuildNodeMap(controller);
+
+                // Find all CampaignGraphObjectiveBubble children
+                foreach (var mb in trackModule.GetComponentsInChildren<MonoBehaviour>(false))
+                {
+                    if (mb == null || mb.GetType().Name != "CampaignGraphObjectiveBubble")
+                        continue;
+
+                    // Get bubble ID to look up match node data
+                    string bubbleId = mb.GetType().GetProperty("ID", PublicInstance)
+                        ?.GetValue(mb) as string;
+                    object matchNode = null;
+                    if (bubbleId != null)
+                        nodeMap?.TryGetValue(bubbleId, out matchNode);
+
+                    string nodeLabel = ReadBubbleInfo(mb, matchNode);
+                    if (!string.IsNullOrEmpty(nodeLabel))
+                        blocks.Add(new CardInfoBlock(Strings.EventInfoLabel, nodeLabel, isVerbose: false));
+                }
+
+                MelonLogger.Msg($"[EventAccessor] GetCampaignGraphInfoBlocks: {blocks.Count} blocks from track module");
+            }
+            catch (Exception ex)
+            {
+                MelonLogger.Error($"[EventAccessor] GetCampaignGraphInfoBlocks failed: {ex.Message}");
+            }
+
+            return blocks;
+        }
+
+        /// <summary>
+        /// Build a dictionary mapping node ID → Client_ColorChallengeMatchNode
+        /// from the strategy's CurrentTrack.Nodes list.
+        /// </summary>
+        private static System.Collections.Generic.Dictionary<string, object> BuildNodeMap(MonoBehaviour controller)
+        {
+            var map = new System.Collections.Generic.Dictionary<string, object>();
+            try
+            {
+                if (_campaignGraphStrategyField == null) return map;
+                var strategy = _campaignGraphStrategyField.GetValue(controller);
+                if (strategy == null) return map;
+
+                var currentTrack = strategy.GetType()
+                    .GetProperty("CurrentTrack", PublicInstance)?.GetValue(strategy);
+                if (currentTrack == null) return map;
+
+                var nodesList = currentTrack.GetType()
+                    .GetProperty("Nodes", PublicInstance)?.GetValue(currentTrack)
+                    as System.Collections.IList;
+                if (nodesList == null) return map;
+
+                foreach (var node in nodesList)
+                {
+                    if (node == null) continue;
+                    var id = node.GetType().GetField("Id")?.GetValue(node) as string;
+                    if (!string.IsNullOrEmpty(id))
+                        map[id] = node;
+                }
+            }
+            catch (Exception ex)
+            {
+                MelonLogger.Warning($"[EventAccessor] BuildNodeMap failed: {ex.Message}");
+            }
+            return map;
+        }
+
+        /// <summary>
+        /// Read a single CampaignGraphObjectiveBubble's display info, optionally enriched
+        /// with data from the matching Client_ColorChallengeMatchNode.
+        /// Returns e.g. "Challenge II: Completed, AI Match, Reward: 100 Gold" or "Challenge III: Locked".
+        /// </summary>
+        private static string ReadBubbleInfo(MonoBehaviour bubble, object matchNode = null)
+        {
+            try
+            {
+                var bubbleType = bubble.GetType();
+
+                // Read roman numeral from _circleText (TextMeshProUGUI)
+                var circleTextField = bubbleType.GetField("_circleText", PrivateInstance);
+                string roman = null;
+                if (circleTextField != null)
+                {
+                    var tmp = circleTextField.GetValue(bubble) as TMPro.TMP_Text;
+                    if (tmp != null)
+                        roman = tmp.text?.Trim();
+                }
+
+                // Read status from Animator bools via reflection (Animator type is
+                // in UnityEngine.AnimationModule which isn't referenced)
+                string status = null;
+                var animatorField = bubbleType.GetField("_animator", PrivateInstance);
+                if (animatorField != null)
+                {
+                    var animator = animatorField.GetValue(bubble);
+                    if (animator != null)
+                    {
+                        var getBool = animator.GetType().GetMethod("GetBool", new[] { typeof(string) });
+                        if (getBool != null)
+                        {
+                            bool locked = (bool)getBool.Invoke(animator, new object[] { "Locked" });
+                            bool completed = (bool)getBool.Invoke(animator, new object[] { "Completed" });
+                            bool selected = (bool)getBool.Invoke(animator, new object[] { "Selected" });
+
+                            if (completed)
+                                status = Strings.ColorChallengeNodeCompleted;
+                            else if (selected)
+                                status = Strings.ColorChallengeNodeCurrent;
+                            else if (locked)
+                                status = Strings.ColorChallengeNodeLocked;
+                            else
+                                status = Strings.ColorChallengeNodeAvailable;
+                        }
+                    }
+                }
+
+                // Read reward popup text if available (from EPPRewardWebHanger on the bubble)
+                string rewardText = null;
+                var popupField = bubbleType.GetField("_notificationPopup", PrivateInstance);
+                if (popupField != null)
+                {
+                    var popup = popupField.GetValue(bubble) as MonoBehaviour;
+                    if (popup != null)
+                    {
+                        var titleField = popup.GetType().GetField("_titleLabel", PrivateInstance);
+                        var descField = popup.GetType().GetField("_descriptionLabel", PrivateInstance);
+
+                        string title = ReadLocalizeText(titleField, popup);
+                        string desc = ReadLocalizeText(descField, popup);
+
+                        if (IsPlaceholderText(desc)) desc = null;
+                        if (IsPlaceholderText(title)) title = null;
+
+                        if (!string.IsNullOrEmpty(title))
+                            rewardText = !string.IsNullOrEmpty(desc) ? $"{title}: {desc}" : title;
+                    }
+                }
+
+                // Enrich from Client_ColorChallengeMatchNode data
+                string matchType = null;
+                string nodeRewardText = null;
+                bool hasDeckUpgrade = false;
+                if (matchNode != null)
+                {
+                    var nodeType = matchNode.GetType();
+
+                    // IsPvpMatch (readonly bool field)
+                    var pvpField = nodeType.GetField("IsPvpMatch");
+                    if (pvpField != null)
+                    {
+                        bool isPvp = (bool)pvpField.GetValue(matchNode);
+                        matchType = isPvp ? Strings.ColorChallengeMatchPvP : Strings.ColorChallengeMatchAI;
+                    }
+
+                    // DeckUpgradeData (readonly field, null if no upgrade)
+                    var upgradeField = nodeType.GetField("DeckUpgradeData");
+                    if (upgradeField != null)
+                    {
+                        var upgradeData = upgradeField.GetValue(matchNode);
+                        if (upgradeData != null)
+                        {
+                            hasDeckUpgrade = true;
+                            var cardsField = upgradeData.GetType().GetProperty("CardsAdded", PublicInstance)
+                                ?? (System.Reflection.MemberInfo)upgradeData.GetType().GetField("CardsAdded");
+                            if (cardsField != null)
+                            {
+                                object cardsList = cardsField is PropertyInfo pi
+                                    ? pi.GetValue(upgradeData)
+                                    : ((FieldInfo)cardsField).GetValue(upgradeData);
+                                if (cardsList is System.Collections.IList cl && cl.Count > 0)
+                                    hasDeckUpgrade = true;
+                            }
+                        }
+                    }
+
+                    // Reward from data model (fallback when popup has no text)
+                    if (string.IsNullOrEmpty(rewardText))
+                    {
+                        var rewardField = nodeType.GetField("Reward");
+                        if (rewardField != null)
+                        {
+                            var reward = rewardField.GetValue(matchNode);
+                            if (reward != null)
+                                nodeRewardText = ReadRewardDisplayText(reward);
+                        }
+                    }
+                }
+
+                // Build final label
+                string challengeLabel = !string.IsNullOrEmpty(roman)
+                    ? Strings.ColorChallengeNode(roman) : Strings.ColorChallengeNode("?");
+
+                var parts = new System.Collections.Generic.List<string>();
+                parts.Add(challengeLabel);
+                if (!string.IsNullOrEmpty(status))
+                    parts.Add(status);
+                if (!string.IsNullOrEmpty(matchType))
+                    parts.Add(matchType);
+                // Popup text already includes its own title (e.g. "Reward: ..."),
+                // so don't wrap it again. Only wrap strategy-sourced text.
+                if (!string.IsNullOrEmpty(rewardText))
+                    parts.Add(rewardText);
+                else if (!string.IsNullOrEmpty(nodeRewardText))
+                    parts.Add(Strings.ColorChallengeReward(nodeRewardText));
+                if (hasDeckUpgrade)
+                    parts.Add(Strings.ColorChallengeDeckUpgrade);
+
+                return string.Join(", ", parts);
+            }
+            catch (Exception ex)
+            {
+                MelonLogger.Error($"[EventAccessor] ReadBubbleInfo failed: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Read localized text from a RewardDisplayData object.
+        /// Tries MainText first, then RewardText. MTGALocalizedString.ToString()
+        /// resolves through the game's localization system.
+        /// </summary>
+        private static string ReadRewardDisplayText(object reward)
+        {
+            try
+            {
+                var rType = reward.GetType();
+
+                // Try MainText first (primary reward header)
+                var mainTextField = rType.GetField("MainText");
+                if (mainTextField != null)
+                {
+                    var mainText = mainTextField.GetValue(reward);
+                    if (mainText != null)
+                    {
+                        string text = mainText.ToString();
+                        if (!string.IsNullOrEmpty(text) && !IsPlaceholderText(text))
+                            return UITextExtractor.CleanText(text);
+                    }
+                }
+
+                // Fallback to RewardText
+                var rewardTextField = rType.GetField("RewardText");
+                if (rewardTextField != null)
+                {
+                    var rewardText = rewardTextField.GetValue(reward);
+                    if (rewardText != null)
+                    {
+                        string text = rewardText.ToString();
+                        if (!string.IsNullOrEmpty(text) && !IsPlaceholderText(text))
+                            return UITextExtractor.CleanText(text);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                MelonLogger.Warning($"[EventAccessor] ReadRewardDisplayText failed: {ex.Message}");
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Read text from a Localize component field (gets its TMP_Text child).
+        /// </summary>
+        private static string ReadLocalizeText(FieldInfo field, MonoBehaviour owner)
+        {
+            if (field == null) return null;
+            var localizeComp = field.GetValue(owner) as MonoBehaviour;
+            if (localizeComp == null) return null;
+            var tmp = localizeComp.GetComponentInChildren<TMPro.TMP_Text>();
+            if (tmp != null && !string.IsNullOrEmpty(tmp.text))
+                return UITextExtractor.CleanText(tmp.text);
+            return null;
+        }
+
+        /// <summary>
+        /// Detect developer placeholder/template text that shouldn't be read aloud.
+        /// </summary>
+        private static bool IsPlaceholderText(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return false;
+            // Known placeholder patterns in Color Challenge reward popups
+            if (text.Contains("character max)")) return true;
+            if (text.Contains("short sentences go here")) return true;
+            if (text.Contains("wraps to")) return true;
+            if (text.StartsWith("Color mastery description")) return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Fallback: read Color Challenge info from strategy data when the track module
+        /// is not visible (e.g., before entering playing mode). Reads track-level summary.
+        /// </summary>
+        private static System.Collections.Generic.List<CardInfoBlock> GetCampaignGraphInfoFromStrategy()
+        {
+            var blocks = new System.Collections.Generic.List<CardInfoBlock>();
+
+            try
+            {
+                var controller = FindCampaignGraphController();
+                if (controller == null || _campaignGraphStrategyField == null) return blocks;
+
+                var strategy = _campaignGraphStrategyField.GetValue(controller);
+                if (strategy == null) return blocks;
+
+                var stratType = strategy.GetType();
+                var currentTrackProp = stratType.GetProperty("CurrentTrack", PublicInstance);
+                if (currentTrackProp == null) return blocks;
+
+                var currentTrack = currentTrackProp.GetValue(strategy);
+                if (currentTrack == null) return blocks;
+
+                var trackType = currentTrack.GetType();
+                string trackName = trackType.GetProperty("Name", PublicInstance)?.GetValue(currentTrack) as string;
+                bool completed = (bool)(trackType.GetProperty("Completed", PublicInstance)?.GetValue(currentTrack) ?? false);
+                int unlocked = (int)(trackType.GetProperty("UnlockedMatchNodeCount", PublicInstance)?.GetValue(currentTrack) ?? 0);
+
+                int total = 0;
+                var nodesProp = trackType.GetProperty("Nodes", PublicInstance);
+                if (nodesProp != null)
+                {
+                    var nodes = nodesProp.GetValue(currentTrack);
+                    if (nodes != null)
+                    {
+                        var countProp = nodes.GetType().GetProperty("Count", PublicInstance);
+                        if (countProp != null) total = (int)countProp.GetValue(nodes);
+                    }
+                }
+
+                string summary = Strings.ColorChallengeProgress(trackName, unlocked, total, completed);
+                if (!string.IsNullOrEmpty(summary))
+                    blocks.Add(new CardInfoBlock(Strings.EventInfoLabel, summary, isVerbose: false));
+
+                MelonLogger.Msg($"[EventAccessor] GetCampaignGraphInfoFromStrategy: {blocks.Count} blocks");
+            }
+            catch (Exception ex)
+            {
+                MelonLogger.Error($"[EventAccessor] GetCampaignGraphInfoFromStrategy failed: {ex.Message}");
+            }
+
+            return blocks;
+        }
+
+        private static MonoBehaviour FindCampaignGraphController()
+        {
+            if (_cachedCampaignGraphController != null)
+            {
+                try
+                {
+                    if (_cachedCampaignGraphController.gameObject != null &&
+                        _cachedCampaignGraphController.gameObject.activeInHierarchy)
+                        return _cachedCampaignGraphController;
+                }
+                catch { /* Cached object may have been destroyed */ }
+                _cachedCampaignGraphController = null;
+            }
+
+            foreach (var mb in GameObject.FindObjectsOfType<MonoBehaviour>())
+            {
+                if (mb == null || !mb.gameObject.activeInHierarchy) continue;
+                if (mb.GetType().Name == "CampaignGraphContentController")
+                {
+                    _cachedCampaignGraphController = mb;
+
+                    if (!_campaignGraphReflectionInit)
+                        InitCampaignGraphReflection(mb.GetType());
+
+                    return mb;
+                }
+            }
+
+            return null;
+        }
+
+        private static void InitCampaignGraphReflection(Type type)
+        {
+            if (_campaignGraphReflectionInit) return;
+
+            _campaignGraphStrategyField = type.GetField("_strategy", PrivateInstance);
+
+            _campaignGraphReflectionInit = true;
+
+            MelonLogger.Msg($"[EventAccessor] CampaignGraph reflection init: " +
+                $"strategy={_campaignGraphStrategyField != null}");
+        }
+
+        #endregion
+
         #region Utility
 
         /// <summary>
@@ -984,6 +1411,7 @@ namespace AccessibleArena.Core.Services
         {
             _cachedEventPageController = null;
             _cachedPacketController = null;
+            _cachedCampaignGraphController = null;
         }
 
         #endregion

--- a/src/Core/Services/GeneralMenuNavigator.cs
+++ b/src/Core/Services/GeneralMenuNavigator.cs
@@ -979,11 +979,9 @@ namespace AccessibleArena.Core.Services
             {
                 InjectEventInfoGroup();
             }
-
-            if (_elements.Count > 0)
+            else if (_activeContentController == "CampaignGraphContentController")
             {
-                _currentIndex = 0;
-                UpdateEventSystemSelection();
+                InjectCampaignGraphInfoGroup();
             }
 
             // After rescan, announce the results
@@ -2999,6 +2997,10 @@ namespace AccessibleArena.Core.Services
             {
                 InjectEventInfoGroup();
             }
+            else if (_activeContentController == "CampaignGraphContentController")
+            {
+                InjectCampaignGraphInfoGroup();
+            }
 
             // Try to find the previously selected object in the new element list
             if (previousSelection != null)
@@ -4932,6 +4934,13 @@ namespace AccessibleArena.Core.Services
             var result = UIActivator.Activate(element);
             _announcer.Announce(result.Message, Models.AnnouncementPriority.Normal);
 
+            // Color Challenge: activating a color button changes the track, so rescan
+            // to refresh info blocks and deck name
+            if (_activeContentController == "CampaignGraphContentController")
+            {
+                TriggerRescan();
+            }
+
             // Note: Mailbox mail item selection is detected via Harmony patch on OnLetterSelected
             // which announces the mail content directly with actual letter data
 
@@ -5406,6 +5415,58 @@ namespace AccessibleArena.Core.Services
                 );
 
                 // Subsequent blocks insert after the last EventInfo
+                insertAfter = ElementGrouping.ElementGroup.EventInfo;
+            }
+        }
+
+        #endregion
+
+        #region Color Challenge Info Virtual Group
+
+        /// <summary>
+        /// Injects Color Challenge node info as virtual elements into the grouped navigator.
+        /// Reads the objective nodes from CampaignGraphTrackModule (via EventAccessor)
+        /// and adds them as navigable info blocks showing each node's status and reward.
+        /// This matches the game's visual display of objective bubbles with their popups.
+        /// </summary>
+        private void InjectCampaignGraphInfoGroup()
+        {
+            if (!_groupedNavigationEnabled || !_groupedNavigator.IsActive)
+                return;
+
+            var blocks = EventAccessor.GetCampaignGraphInfoBlocks();
+            if (blocks == null || blocks.Count == 0)
+            {
+                MelonLogger.Msg($"[{NavigatorId}] EventAccessor returned no CampaignGraph info blocks");
+                return;
+            }
+            MelonLogger.Msg($"[{NavigatorId}] Injecting {blocks.Count} CampaignGraph info elements");
+
+            ElementGroup? insertAfter = null;
+            foreach (var block in blocks)
+            {
+                string label = string.IsNullOrEmpty(block.Label)
+                    ? block.Content
+                    : $"{block.Label}: {block.Content}";
+
+                var elements = new List<ElementGrouping.GroupedElement>
+                {
+                    new ElementGrouping.GroupedElement
+                    {
+                        GameObject = null,
+                        Label = label,
+                        Group = ElementGrouping.ElementGroup.EventInfo
+                    }
+                };
+
+                _groupedNavigator.AddVirtualGroup(
+                    ElementGrouping.ElementGroup.EventInfo,
+                    elements,
+                    insertAfter: insertAfter,
+                    isStandalone: true,
+                    displayName: label
+                );
+
                 insertAfter = ElementGrouping.ElementGroup.EventInfo;
             }
         }

--- a/tools/decompile.ps1
+++ b/tools/decompile.ps1
@@ -24,7 +24,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 # Paths
-$managedDir = "C:\Program Files\Wizards of the Coast\MTGA\MTGA_Data\Managed"
+$managedDir = "C:\Program Files (x86)\Steam\steamapps\common\MTGA\MTGA_Data\Managed"
 $ilspycmd = "$env:USERPROFILE\.dotnet\tools\ilspycmd.exe"
 $repoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
 


### PR DESCRIPTION
## Summary

Add navigable info blocks to the Color Challenge screen showing node status, match type, and rewards.

## Changes

### Color Challenge Node Info Blocks
- Read objective bubble data from CampaignGraphTrackModule via reflection
- Display 5 challenge nodes (I-V) with status: Completed, Current, Available, Locked
- Show match type per node: AI Match (PvE) or PvP Match
- Show reward text from visible bubble popup (e.g. Card Style, 1 Uncommon & 2 Common Wildcards)
- Filter out developer placeholder text in reward descriptions
- Navigable via Up/Down arrows in the info block group
- Info blocks refresh when switching colors (TriggerRescan on CampaignGraph activation)
- Falls back to track-level summary when track module not visible

### New Localization Keys
- Added 13 ColorChallenge* keys to all 12 locale files
- Strings: ColorChallengeProgress, ColorChallengeNode, status labels, match type labels, reward format

### Technical
- EventAccessor: GetCampaignGraphInfoBlocks(), ReadBubbleInfo(), BuildNodeMap(), ReadRewardDisplayText(), IsPlaceholderText()
- GeneralMenuNavigator: InjectCampaignGraphInfoGroup(), TriggerRescan for CampaignGraph context
- Animator.GetBool() and all game type access via reflection

---
AI-assisted implementation: GitHub Copilot (Claude Opus 4.6)
Human testing/verification: blindndangerous