### PR TITLE
Fix quest swap confirm locked in popup mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Accessible Arena.
 
+## Unreleased
+
+### Fixed: Quest Swap Confirm Cannot Be Dismissed
+- Pressing Cancel (or Backspace) on the quest swap confirmation dialog now correctly exits popup mode
+- Root cause: a passive XP coin animation (`RewardPopup3DIcon_XPCoin`) registers as a popup at the same time as the swap dialog; when the dialog closes, the animation becomes the active panel and the popup mode handler had no case for switching between popups — leaving navigation locked on the dismissed dialog's buttons
+- Fixed by ignoring `RewardPopup3DIcon` passive animations in the panel tracking system and adding a popup-switching case to the popup mode handler
+
 ## v0.8.2
 
 ### New: Brawl Commander Deck Building

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -32,9 +32,11 @@ Fixed: Selecting a color button now triggers a rescan so the deck name refreshes
 
 ---
 
-### Weekly Progress Enter Locks Mod
+### ~~Weekly Progress Enter Locks Mod~~ (Fixed)
 
-Pressing Enter on the Weekly Progress element puts the mod in a locked state requiring screen transition to recover.
+~~Pressing Enter on the Weekly Progress element puts the mod in a locked state requiring screen transition to recover.~~
+
+Fixed: When the user pressed Cancel on the quest swap confirm dialog, a passive XP coin animation popup (`RewardPopup3DIcon_XPCoin`) had already registered as an active panel. When the dialog closed, this animation became the new active panel and the popup mode switch handler in `BaseNavigator` had no case for "active popup changed to a different popup" — leaving popup mode locked on the dead dialog's elements. Fixed by: (1) adding `RewardPopup3DIcon` to `PanelInfo.IgnoredPanels` so passive coin animations never filter navigation, and (2) adding a popup-switching case to `BaseNavigator.OnPopupPanelChanged`.
 
 ---
 

--- a/src/AccessibleArena.csproj
+++ b/src/AccessibleArena.csproj
@@ -24,9 +24,12 @@
     </ItemGroup>
   </Target>
 
-  <!-- Game install path - adjust if your MTGA is installed elsewhere -->
+  <!-- Game install path - override via local.props (local, gitignored) if installed elsewhere.
+       Default assumes the Wizards of the Coast store install location.
+       To override: create src/local.props with <MtgaPath>your path</MtgaPath> -->
+  <Import Project="$(MSBuildProjectDirectory)\local.props" Condition="Exists('$(MSBuildProjectDirectory)\local.props')" />
   <PropertyGroup>
-    <MtgaPath>C:\Program Files\Wizards of the Coast\MTGA</MtgaPath>
+    <MtgaPath Condition="'$(MtgaPath)' == ''">C:\Program Files\Wizards of the Coast\MTGA</MtgaPath>
     <MtgaManagedPath>$(MtgaPath)\MTGA_Data\Managed</MtgaManagedPath>
     <MelonLoaderPath>$(MtgaPath)\MelonLoader\net35</MelonLoaderPath>
   </PropertyGroup>

--- a/src/Core/Services/BaseNavigator.cs
+++ b/src/Core/Services/BaseNavigator.cs
@@ -2070,10 +2070,23 @@ namespace AccessibleArena.Core.Services
         {
             if (!_isActive) return;
 
-            if (newPanel != null && !IsPopupExcluded(newPanel) && IsPopupPanel(newPanel))
+            bool newIsHandledPopup = newPanel != null && !IsPopupExcluded(newPanel) && IsPopupPanel(newPanel);
+
+            if (newIsHandledPopup)
             {
                 if (!_isInPopupMode)
                 {
+                    MelonLogger.Msg($"[{NavigatorId}] Popup detected: {newPanel.Name}");
+                    OnPopupDetected(newPanel);
+                }
+                else if (_popupGameObject != newPanel.GameObject)
+                {
+                    // Active popup switched to a different popup while we were already in popup mode
+                    // (e.g., a swap confirm dialog closed while an XP reward popup was queued).
+                    // Exit the stale popup mode then enter the new one.
+                    MelonLogger.Msg($"[{NavigatorId}] Popup switched: {_popupGameObject?.name} -> {newPanel.Name}");
+                    ExitPopupMode();
+                    OnPopupClosed();
                     MelonLogger.Msg($"[{NavigatorId}] Popup detected: {newPanel.Name}");
                     OnPopupDetected(newPanel);
                 }

--- a/src/Core/Services/PanelDetection/PanelInfo.cs
+++ b/src/Core/Services/PanelDetection/PanelInfo.cs
@@ -148,7 +148,11 @@ namespace AccessibleArena.Core.Services.PanelDetection
             System.StringComparer.OrdinalIgnoreCase)
         {
             "NavBar",
-            "TopBar"
+            "TopBar",
+            // Passive 3D reward animations (XP coin, gem, etc.) — visual-only, no navigable elements,
+            // close automatically. Tracking them causes popup mode to get stuck when they become
+            // the active panel after a real dialog closes (e.g., quest swap confirm).
+            "RewardPopup3DIcon",
         };
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes the bug where pressing Cancel on the quest swap confirmation dialog locked the mod in popup mode, requiring a screen transition to recover.

## Root Cause

When the user presses Enter on a quest element, two things happen nearly simultaneously:
1. \SystemMessageView_Desktop_16x9\ opens (the swap confirm dialog)
2. \RewardPopup3DIcon_XPCoin\ opens ~1 second later (a passive XP coin animation)

Both register as Popup panels at Priority=1000. When the user pressed Cancel, \SystemMessageView\ closed and \RewardPopup3DIcon_XPCoin\ became the new active panel. \BaseNavigator.OnPopupPanelChanged\ had no handler for the case \u201calready in popup mode for popup A, active panel changed to a different popup B\u201d \u2014 so popup mode stayed locked on the dead dialog\u2019s elements forever. Every subsequent Backspace kept firing \OnClick.Invoke()\ on the dismissed Cancel button.

## Fix

**Primary \u2014 \PanelInfo.cs\:**  
Added \\u201cRewardPopup3DIcon\u201d\ to \IgnoredPanels\. These passive 3D coin/gem animations are visual-only, close automatically, and should never filter navigation or become active panels. With this, when \SystemMessageView\ closes the active panel falls back to \
ull\ and popup mode exits via the normal path.

**Defensive \u2014 \BaseNavigator.cs\:**  
Added a popup-switching case to \OnPopupPanelChanged\: when already in popup mode for popup A and the active panel changes to a different popup B, exit A\u2019s mode and enter B\u2019s. Prevents this class of bug in any future scenario.

**Build fix \u2014 \AccessibleArena.csproj\:**  
Made \MtgaPath\ conditional so it can be overridden via a gitignored \local.props\ file. Useful for contributors with non-default MTGA install locations (e.g. Steam).

## Files Changed

- \src/Core/Services/PanelDetection/PanelInfo.cs\ \u2014 add RewardPopup3DIcon to IgnoredPanels
- \src/Core/Services/BaseNavigator.cs\ \u2014 handle popup-switching in OnPopupPanelChanged
- \src/AccessibleArena.csproj\ \u2014 conditional MtgaPath with local.props override support
- \docs/KNOWN_ISSUES.md\ \u2014 mark Weekly Progress Enter Locks Mod as fixed
- \docs/CHANGELOG.md\ \u2014 add Unreleased entry

## Testing

- Go to Progress > Quests
- Press Enter on any quest
- The swap confirmation popup should announce and be navigable
- Press Cancel or Backspace \u2014 popup should dismiss and return to normal navigation
- Verify no further keypresses are consumed by the dead popup

---

AI-assisted implementation: GitHub Copilot (claude-sonnet-4.6)  
Human testing/verification: blindndangerous