### PR TITLE
fix: Play blade navigation when opened from home screen objectives

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Accessible Arena.
 
+## v0.8.3
+
+### Fix: Play blade navigation when opened from a home screen objective
+- When pressing Enter on a tracked Sparked-Rank achievement (Progress > Objectives), the Play blade now navigates correctly, matching the behavior of Play > Play
+- Backspace now correctly closes the blade and returns to the objectives screen
+- Root cause: the `EventBlade` panel type (fired by `HomePageContentController.IsEventBladeActive`) was not calling `SetPlayBladeState`, so the mod never knew the blade had opened
+- Fix: `HarmonyPanelDetector` now sets `PlayBladeState=1` when `EventBlade` opens and `PlayBladeState=0` when it closes
+- Added `OnPlayBladeStateChanged` subscription in `GeneralMenuNavigator` as a direct, debounce-proof signal for blade state changes
+
 ## v0.8.2
 
 ### New: Brawl Commander Deck Building

--- a/src/Core/Services/ElementGrouping/GroupedNavigator.cs
+++ b/src/Core/Services/ElementGrouping/GroupedNavigator.cs
@@ -562,6 +562,7 @@ namespace AccessibleArena.Core.Services.ElementGrouping
             _currentGroupIndex = -1;
             _currentElementIndex = -1;
             _navigationLevel = NavigationLevel.GroupList;
+            _currentSubgroup = null;
 
             // First pass: identify folder toggles and their names
             var folderToggles = new Dictionary<string, GameObject>(); // folderName -> toggle GameObject

--- a/src/Core/Services/GeneralMenuNavigator.cs
+++ b/src/Core/Services/GeneralMenuNavigator.cs
@@ -330,6 +330,7 @@ namespace AccessibleArena.Core.Services
             {
                 PanelStateManager.Instance.OnPanelChanged += OnPanelStateManagerActiveChanged;
                 PanelStateManager.Instance.OnAnyPanelOpened += OnPanelStateManagerAnyOpened;
+                PanelStateManager.Instance.OnPlayBladeStateChanged += OnPanelStateManagerPlayBladeChanged;
             }
 
             // Subscribe to mail letter selection events
@@ -488,6 +489,22 @@ namespace AccessibleArena.Core.Services
                 _bladeAutoExpandDelay = BladeAutoExpandDelay;
                 LogDebug($"[{NavigatorId}] Scheduling blade auto-expand for Color Challenge");
             }
+
+            TriggerRescan();
+        }
+
+        /// <summary>
+        /// Handler for PanelStateManager.OnPlayBladeStateChanged - fires when blade state changes.
+        /// This is a direct signal that bypasses the panel debounce, ensuring the blade helper
+        /// is initialized even when OnAnyPanelOpened is debounced away.
+        /// </summary>
+        private void OnPanelStateManagerPlayBladeChanged(int state)
+        {
+            if (!_isActive) return;
+
+            MelonLogger.Msg($"[{NavigatorId}] PlayBladeStateChanged: state={state}");
+            CheckAndInitPlayBladeHelper("BladeStateChanged");
+            CheckAndInitChallengeHelper("BladeStateChanged");
 
             TriggerRescan();
         }
@@ -1115,6 +1132,16 @@ namespace AccessibleArena.Core.Services
             {
                 MelonLogger.Msg($"[{NavigatorId}] Overlay changed: {_lastKnownOverlay?.ToString() ?? "none"} -> {currentOverlay?.ToString() ?? "none"}");
                 _lastKnownOverlay = currentOverlay;
+
+                // When the overlay changes to a PlayBlade state, also initialize the play blade helper.
+                // This catches the case where the blade is opened from a home screen objective
+                // (the Harmony panel events may fire before Btn_BladeIsOpen is active, causing
+                // CheckAndInitPlayBladeHelper to miss it; the overlay poll detects it reliably).
+                if (currentOverlay == ElementGroup.PlayBladeTabs || currentOverlay == ElementGroup.ChallengeMain)
+                {
+                    CheckAndInitPlayBladeHelper("OverlayChange");
+                    CheckAndInitChallengeHelper("OverlayChange");
+                }
 
                 // Only trigger rescan if we're not already waiting for one
                 if (_rescanDelay <= 0)

--- a/src/Core/Services/PanelDetection/HarmonyPanelDetector.cs
+++ b/src/Core/Services/PanelDetection/HarmonyPanelDetector.cs
@@ -150,6 +150,14 @@ namespace AccessibleArena.Core.Services.PanelDetection
                             MelonLogger.Msg($"[{DetectorId}] Set PlayBladeState={bladeState} from content view: {contentView}");
                         }
                     }
+                    else if (typeName == "EventBlade")
+                    {
+                        // HomePageContentController.IsEventBladeActive = true
+                        // This fires when the play blade opens from home screen objectives
+                        // (e.g., Sparked Rank achievement). Treat it as PlayBlade state 1.
+                        _stateManager.SetPlayBladeState(1);
+                        MelonLogger.Msg($"[{DetectorId}] Set PlayBladeState=1 from EventBlade");
+                    }
 
                     _stateManager.ReportPanelOpened(panelInfo);
                     MelonLogger.Msg($"[{DetectorId}] Reported panel opened: {typeName}");
@@ -171,6 +179,12 @@ namespace AccessibleArena.Core.Services.PanelDetection
                         // BladeContentView hiding - blade is closing
                         _stateManager.SetPlayBladeState(0);
                         MelonLogger.Msg($"[{DetectorId}] Set PlayBladeState=0 from content view closing: {typeName}");
+                    }
+                    else if (typeName == "EventBlade")
+                    {
+                        // HomePageContentController.IsEventBladeActive = false
+                        _stateManager.SetPlayBladeState(0);
+                        MelonLogger.Msg($"[{DetectorId}] Set PlayBladeState=0 from EventBlade closing");
                     }
 
                     // Report panel closed


### PR DESCRIPTION
## Summary

Fixes Play blade navigation when the blade is opened from a home screen objective (e.g. Progress > Objectives > Sparked Rank > Enter). Previously, Down/Up arrow keys produced no announcements within the blade tabs, even though the blade was detected and auto-entered.

## Root Causes

**1. EventBlade panel type not handled**
`HarmonyPanelDetector` only recognized `"PlayBlade:"` and `"Blade:"` prefixed panel types. The `"EventBlade"` type (fired by `HomePageContentController.IsEventBladeActive`) was silently ignored, so the mod never detected the blade opening via the Harmony event path.

**2. Stale subgroup state across rescans (the real blocker)**
`GroupedNavigator.OrganizeIntoGroups()` cleared groups, indices, and navigation level on reset — but never cleared `_currentSubgroup`. When the user was previously inside the Objectives subgroup (Progress > Objectives), that stale `_currentSubgroup` caused `GetCurrentElement()` and `GetCurrentElementCount()` to look up the wrong element list, making all navigation return null.

## Fix

- **HarmonyPanelDetector**: Handle `EventBlade` by calling `SetPlayBladeState(1)` on open, `SetPlayBladeState(0)` on close
- **GroupedNavigator**: Clear `_currentSubgroup = null` in `OrganizeIntoGroups()` to prevent stale subgroup state
- **GeneralMenuNavigator**: Subscribe to `OnPlayBladeStateChanged` as a direct, debounce-proof signal; also detect PlayBlade overlays in the Update() poll as fallback

## Testing

1. Navigate to Progress > Objectives
2. Find the Sparked Rank achievement and press Enter
3. Play blade should open and announce "Play Mode Selection"
4. Down/Up arrows should navigate blade tabs with position announcements (e.g. "Ranked, button, 3 of 5")
5. Backspace should close the blade and return to objectives
6. Verify normal Play > Play blade still works identically

---

AI-assisted implementation: GitHub Copilot (claude-opus-4.6)
Human testing/verification: blindndangerous