### PR TITLE
fix: Store tab announcements use 'tab X of Y' and label utilities as buttons

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -374,6 +374,7 @@
   "NoDetailsAvailable": "No details available",
   "NoCardDetails": "No card details available",
   "Tabs_Format": "Tabs. {0} tabs.",
+  "TabPositionOf_Format": "{2}, tab {0} of {1}",
   "OptionsAvailable_Format": "{0} options available. {1}",
   "Continuing": "Continuing",
   "FoundRewards_Format": "Found {0} rewards",

--- a/src/Core/Models/Strings.cs
+++ b/src/Core/Models/Strings.cs
@@ -968,6 +968,8 @@ namespace AccessibleArena.Core.Models
         public static string NoDetailsAvailable => L.Get("NoDetailsAvailable");
         public static string NoCardDetails => L.Get("NoCardDetails");
         public static string TabsCount(int count) => L.Format("Tabs_Format", count);
+        public static string TabPositionOf(int index, int total, string label) =>
+            L.Format("TabPositionOf_Format", index, total, label);
         public static string OptionsAvailable(int count, string hint) => L.Format("OptionsAvailable_Format", count, hint);
         public static string Continuing => L.Get("Continuing");
         public static string FoundRewards(int count) => L.Format("FoundRewards_Format", count);

--- a/src/Core/Services/StoreNavigator.cs
+++ b/src/Core/Services/StoreNavigator.cs
@@ -1110,7 +1110,8 @@ namespace AccessibleArena.Core.Services
 
             // No items - stay at tab level
             _navLevel = NavigationLevel.Tabs;
-            return $"Store. {Strings.NavigateWithArrows}, Enter to select. {_tabs.Count} tabs.";
+            int realTabCount = _tabs.Count(t => !t.IsUtility);
+            return $"Store. {Strings.NavigateWithArrows}, Enter to select. {realTabCount} tabs.";
         }
 
         protected override string GetElementAnnouncement(int index)
@@ -1127,15 +1128,16 @@ namespace AccessibleArena.Core.Services
 
             if (tab.IsUtility)
             {
-                _announcer.AnnounceInterrupt(
-                    $"{tab.DisplayName}, {_currentTabIndex + 1} of {_tabs.Count}");
+                _announcer.AnnounceInterrupt($"{tab.DisplayName}, button");
             }
             else
             {
+                int tabCount = _tabs.Count(t => !t.IsUtility);
                 bool isActive = IsTabActive(tab);
                 string activeIndicator = isActive ? ", active" : "";
                 _announcer.AnnounceInterrupt(
-                    $"{tab.DisplayName}{activeIndicator}, {_currentTabIndex + 1} of {_tabs.Count}");
+                    Strings.TabPositionOf(_currentTabIndex + 1, tabCount,
+                        $"{tab.DisplayName}{activeIndicator}"));
             }
         }
 
@@ -2723,7 +2725,7 @@ namespace AccessibleArena.Core.Services
             if (_currentTabIndex < 0 && _tabs.Count > 0)
                 _currentTabIndex = 0;
 
-            _announcer.AnnounceInterrupt(Strings.TabsCount(_tabs.Count));
+            _announcer.AnnounceInterrupt(Strings.TabsCount(_tabs.Count(t => !t.IsUtility)));
             AnnounceCurrentTab();
         }
 


### PR DESCRIPTION
## Summary

Store tab announcements now clearly distinguish between navigable tabs and utility buttons:

- **Tabs** announce as \Featured, active, tab 1 of 7\ — explicit 'tab' label with position among real tabs only
- **Utilities** announce as \Change payment method, button\ — labeled as buttons with no position counting
- **Screen entry** and **back-to-tabs** announce the correct tab count (excluding utilities)

Previously all items (tabs + utilities) were counted together (e.g. 'Featured, active, 1 of 12'), which was confusing since utilities are distinct actions, not a numbered sequence.

### Changes
- \lang/en.json\: Added \TabPositionOf_Format\ string
- \src/Core/Models/Strings.cs\: Added \TabPositionOf()\ method
- \src/Core/Services/StoreNavigator.cs\: Updated tab/utility announcement logic

---
AI-assisted implementation: GitHub Copilot (claude-opus-4.6)
Human testing/verification: blindndangerous