### PR TITLE
fix: skip deck sub-actions on Recently Played tab

### DIFF
--- a/src/Core/Services/GeneralMenuNavigator.cs
+++ b/src/Core/Services/GeneralMenuNavigator.cs
@@ -3621,20 +3621,25 @@ namespace AccessibleArena.Core.Services
                         announcement += $", {invalidStatus}";
                     }
 
-                    // Get the rename button (TextBox) for this deck
-                    GameObject renameButton = deckEditButtons.TryGetValue(obj, out var editBtn) ? editBtn : null;
-                    attachedActions = BuildDeckAttachedActions(deckToolbarButtons, renameButton);
-
-                    // Insert detailed tooltip as first virtual info item (Level 2)
-                    string invalidTooltip = UIActivator.GetDeckInvalidTooltip(obj);
-                    if (!string.IsNullOrEmpty(invalidTooltip))
+                    // Recent tab decks: skip attached actions (Enter auto-plays; deck toolbar not applicable here)
+                    bool isRecentDeck = RecentPlayAccessor.IsActive;
+                    if (!isRecentDeck)
                     {
-                        attachedActions.Insert(0, new AttachedAction { Label = invalidTooltip, TargetButton = null });
-                    }
+                        // Get the rename button (TextBox) for this deck
+                        GameObject renameButton = deckEditButtons.TryGetValue(obj, out var editBtn) ? editBtn : null;
+                        attachedActions = BuildDeckAttachedActions(deckToolbarButtons, renameButton);
 
-                    if (attachedActions.Count > 0)
-                    {
-                        LogDebug($"[{NavigatorId}] Deck '{announcement}' has {attachedActions.Count} attached actions");
+                        // Insert detailed tooltip as first virtual info item (Level 2)
+                        string invalidTooltip = UIActivator.GetDeckInvalidTooltip(obj);
+                        if (!string.IsNullOrEmpty(invalidTooltip))
+                        {
+                            attachedActions.Insert(0, new AttachedAction { Label = invalidTooltip, TargetButton = null });
+                        }
+
+                        if (attachedActions.Count > 0)
+                        {
+                            LogDebug($"[{NavigatorId}] Deck '{announcement}' has {attachedActions.Count} attached actions");
+                        }
                     }
                 }
 


### PR DESCRIPTION
## What Changed

Deck entries on the Recently Played tab were getting Rename/Edit/Delete/Clone/Export sub-actions attached (via the standard deck left/right cycling mechanism). This caused the Right arrow key to cycle into sub-actions (landing on "Rename" first) instead of navigating to the next recently played tile.

Since pressing Enter on a recently played deck already auto-presses the tile's own play button, sub-action cycling has no purpose here and is now skipped when the Recently Played tab is active.

## Files Updated
- \src/Core/Services/GeneralMenuNavigator.cs\ — skip \BuildDeckAttachedActions\ when \RecentPlayAccessor.IsActive\

## What Was Broken
- Right arrow on a recently played deck entry cycled to "Rename" instead of moving to the next tile
- User had to work around by pressing Left to escape the sub-action state

## What To Test
1. Navigate to Play → Recently Played
2. Left/Right should move between the 4 tile entries cleanly — no "Rename" or other sub-actions
3. Press Enter on any entry — should announce "Deck Selected" and queue/configure the match
4. Confirm normal deck sub-actions (Rename, Edit, etc.) still work in other deck pickers (My Decks, event deck selection)

## Notes
The game's \LastPlayedBladeContentView\ tracks 3 event-based tiles. A 4th deck entry (Open Play/bot matches) appears outside the tile system and does not have a tile play button, so it announces "Deck Selected" and the player navigates to Find Match from there. This is a game architecture constraint.

## Attribution
- AI-assisted implementation: GitHub Copilot
- Human testing/verification: blindndangerous