### PR TITLE
feat: make Account settings screen navigable

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ModLoaded_Format": "Accessible Arena v{0} gestartet",
   "Back": "Zurück",
   "NoSelection": "Keine Auswahl",
@@ -568,6 +568,7 @@
   "ScreenSettingsGameplay": "Einstellungen, Spielverlauf",
   "ScreenSettingsGraphics": "Einstellungen, Grafik",
   "ScreenSettingsAudio": "Einstellungen, Audio",
+  "ScreenSettingsAccount": "Settings, Account",
   "ScreenDownload": "Download",
   "ScreenAdvancedFilters": "Erweiterte Filter",
   "ScreenPrizeWall": "Belohnungswand",

--- a/lang/en.json
+++ b/lang/en.json
@@ -570,6 +570,7 @@
   "ScreenSettingsGameplay": "Settings, Gameplay",
   "ScreenSettingsGraphics": "Settings, Graphics",
   "ScreenSettingsAudio": "Settings, Audio",
+  "ScreenSettingsAccount": "Settings, Account",
   "ScreenDownload": "Download screen",
   "ScreenAdvancedFilters": "Advanced Filters",
   "ScreenPrizeWall": "Prize Wall",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ModLoaded_Format": "Accessible Arena v{0} iniciado",
   "Back": "Atrás",
   "NoSelection": "Sin selección",
@@ -558,6 +558,7 @@
   "ScreenSettingsGameplay": "Ajustes, Jugabilidad",
   "ScreenSettingsGraphics": "Ajustes, Gráficos",
   "ScreenSettingsAudio": "Ajustes, Audio",
+  "ScreenSettingsAccount": "Settings, Account",
   "ScreenDownload": "Descarga",
   "ScreenAdvancedFilters": "Filtros avanzados",
   "ScreenPrizeWall": "Muro de premios",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ModLoaded_Format": "Accessible Arena v{0} lancé",
   "Back": "Retour",
   "NoSelection": "Aucune sélection",
@@ -558,6 +558,7 @@
   "ScreenSettingsGameplay": "Paramètres, Gameplay",
   "ScreenSettingsGraphics": "Paramètres, Graphismes",
   "ScreenSettingsAudio": "Paramètres, Audio",
+  "ScreenSettingsAccount": "Settings, Account",
   "ScreenDownload": "Téléchargement",
   "ScreenAdvancedFilters": "Filtres avancés",
   "ScreenPrizeWall": "Mur de prix",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ModLoaded_Format": "Accessible Arena v{0} avviato",
   "Back": "Indietro",
   "NoSelection": "Nessuna selezione",
@@ -558,6 +558,7 @@
   "ScreenSettingsGameplay": "Impostazioni, Gioco",
   "ScreenSettingsGraphics": "Impostazioni, Grafica",
   "ScreenSettingsAudio": "Impostazioni, Audio",
+  "ScreenSettingsAccount": "Settings, Account",
   "ScreenDownload": "Download",
   "ScreenAdvancedFilters": "Filtri avanzati",
   "ScreenPrizeWall": "Muro dei premi",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ModLoaded_Format": "Accessible Arena v{0} 起動しました",
   "Back": "戻る",
   "NoSelection": "選択なし",
@@ -558,6 +558,7 @@
   "ScreenSettingsGameplay": "設定、ゲームプレイ",
   "ScreenSettingsGraphics": "設定、グラフィック",
   "ScreenSettingsAudio": "設定、オーディオ",
+  "ScreenSettingsAccount": "Settings, Account",
   "ScreenDownload": "ダウンロード",
   "ScreenAdvancedFilters": "詳細フィルター",
   "ScreenPrizeWall": "プライズウォール",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ModLoaded_Format": "Accessible Arena v{0} 시작되었습니다",
   "Back": "뒤로",
   "NoSelection": "선택 없음",
@@ -558,6 +558,7 @@
   "ScreenSettingsGameplay": "설정, 게임플레이",
   "ScreenSettingsGraphics": "설정, 그래픽",
   "ScreenSettingsAudio": "설정, 오디오",
+  "ScreenSettingsAccount": "Settings, Account",
   "ScreenDownload": "다운로드",
   "ScreenAdvancedFilters": "고급 필터",
   "ScreenPrizeWall": "프라이즈 월",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ModLoaded_Format": "Accessible Arena v{0} uruchomiony",
   "Back": "Wstecz",
   "NoSelection": "Brak wyboru",
@@ -558,6 +558,7 @@
   "ScreenSettingsGameplay": "Ustawienia, Rozgrywka",
   "ScreenSettingsGraphics": "Ustawienia, Grafika",
   "ScreenSettingsAudio": "Ustawienia, Dźwięk",
+  "ScreenSettingsAccount": "Settings, Account",
   "ScreenDownload": "Pobieranie",
   "ScreenAdvancedFilters": "Filtry zaawansowane",
   "ScreenPrizeWall": "Ściana nagród",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ModLoaded_Format": "Accessible Arena v{0} iniciado",
   "Back": "Voltar",
   "NoSelection": "Nenhuma seleção",
@@ -558,6 +558,7 @@
   "ScreenSettingsGameplay": "Configurações, Jogabilidade",
   "ScreenSettingsGraphics": "Configurações, Gráficos",
   "ScreenSettingsAudio": "Configurações, Áudio",
+  "ScreenSettingsAccount": "Settings, Account",
   "ScreenDownload": "Download",
   "ScreenAdvancedFilters": "Filtros avançados",
   "ScreenPrizeWall": "Muro de prêmios",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ModLoaded_Format": "Accessible Arena v{0} запущен",
   "Back": "Назад",
   "NoSelection": "Ничего не выбрано",
@@ -558,6 +558,7 @@
   "ScreenSettingsGameplay": "Настройки, Геймплей",
   "ScreenSettingsGraphics": "Настройки, Графика",
   "ScreenSettingsAudio": "Настройки, Звук",
+  "ScreenSettingsAccount": "Settings, Account",
   "ScreenDownload": "Загрузка данных",
   "ScreenAdvancedFilters": "Расширенные фильтры",
   "ScreenPrizeWall": "Стена призов",

--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ModLoaded_Format": "Accessible Arena v{0} 已启动",
   "Back": "返回",
   "NoSelection": "未选择",
@@ -558,6 +558,7 @@
   "ScreenSettingsGameplay": "设置，游戏性",
   "ScreenSettingsGraphics": "设置，画面",
   "ScreenSettingsAudio": "设置，音频",
+  "ScreenSettingsAccount": "Settings, Account",
   "ScreenDownload": "下载",
   "ScreenAdvancedFilters": "高级筛选",
   "ScreenPrizeWall": "奖品墙",

--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ModLoaded_Format": "Accessible Arena v{0} 已啟動",
   "Back": "返回",
   "NoSelection": "未選取",
@@ -558,6 +558,7 @@
   "ScreenSettingsGameplay": "設定，遊戲性",
   "ScreenSettingsGraphics": "設定，畫面",
   "ScreenSettingsAudio": "設定，音訊",
+  "ScreenSettingsAccount": "Settings, Account",
   "ScreenDownload": "下載",
   "ScreenAdvancedFilters": "進階篩選",
   "ScreenPrizeWall": "獎品牆",

--- a/src/Core/Models/Strings.cs
+++ b/src/Core/Models/Strings.cs
@@ -1132,6 +1132,7 @@ namespace AccessibleArena.Core.Models
         public static string ScreenSettingsGameplay => L.Get("ScreenSettingsGameplay");
         public static string ScreenSettingsGraphics => L.Get("ScreenSettingsGraphics");
         public static string ScreenSettingsAudio => L.Get("ScreenSettingsAudio");
+        public static string ScreenSettingsAccount => L.Get("ScreenSettingsAccount");
         public static string ScreenDownload => L.Get("ScreenDownload");
         public static string ScreenAdvancedFilters => L.Get("ScreenAdvancedFilters");
         public static string ScreenPrizeWall => L.Get("ScreenPrizeWall");

--- a/src/Core/Services/SettingsMenuNavigator.cs
+++ b/src/Core/Services/SettingsMenuNavigator.cs
@@ -24,7 +24,8 @@ namespace AccessibleArena.Core.Services
             "Content - MainMenu",
             "Content - Gameplay",
             "Content - Graphics",
-            "Content - Audio"
+            "Content - Audio",
+            "Content - Account"
         };
 
         private const float RescanDelaySeconds = 0.3f;
@@ -103,6 +104,7 @@ namespace AccessibleArena.Core.Services
                 "Content - Gameplay" => Models.Strings.ScreenSettingsGameplay,
                 "Content - Graphics" => Models.Strings.ScreenSettingsGraphics,
                 "Content - Audio" => Models.Strings.ScreenSettingsAudio,
+                "Content - Account" => Models.Strings.ScreenSettingsAccount,
                 _ => Models.Strings.ScreenSettings
             };
         }
@@ -496,7 +498,8 @@ namespace AccessibleArena.Core.Services
             bool isInSubmenu = panelName != "Content - MainMenu" &&
                               (panelName == "Content - Audio" ||
                                panelName == "Content - Graphics" ||
-                               panelName == "Content - Gameplay");
+                               panelName == "Content - Gameplay" ||
+                               panelName == "Content - Account");
 
             if (isInSubmenu)
             {


### PR DESCRIPTION
The Account settings panel was previously unreachable by keyboard — pressing Enter on the Account button would open it but the navigator would not detect the panel change. This adds \Content - Account\ to the list of known settings panels.

**Changes:**
- \SettingsMenuNavigator.cs\: add \Content - Account\ to \SettingsPanelNames\
- \Strings.cs\: add \ScreenSettingsAccount\ accessor
- \lang/en.json\ + 11 other locales: add \ScreenSettingsAccount\ string

**Tested:** Navigating to Settings → Account → Enter enters the Account panel and announces its options correctly.

---
AI-assisted implementation: GitHub Copilot (claude-sonnet-4.6)
Human testing/verification: blindndangerous