### PR TITLE
feat: announce player matchup at duel start

### DIFF
--- a/src/Core/Services/DuelNavigator.cs
+++ b/src/Core/Services/DuelNavigator.cs
@@ -28,6 +28,7 @@ namespace AccessibleArena.Core.Services
 
         private bool _isWatching;
         private bool _hasCenteredMouse;
+        private float _playerNameAnnounceDelay = -1f; // One-shot: announces matchup after HUD settles
         private ZoneNavigator _zoneNavigator;
         private HotHighlightNavigator _hotHighlightNavigator;  // Unified navigator for Tab, cards, targets, selection mode
         private CombatNavigator _combatNavigator;
@@ -129,6 +130,30 @@ namespace AccessibleArena.Core.Services
                 MelonLogger.Msg($"[{NavigatorId}] Centered mouse cursor at ({centerX}, {centerY})");
                 _hasCenteredMouse = true;
             }
+
+            // Schedule a matchup announcement once the HUD has fully settled
+            _playerNameAnnounceDelay = 1.5f;
+        }
+
+        public override void Update()
+        {
+            // One-shot matchup announcement after HUD settles
+            if (_playerNameAnnounceDelay > 0f)
+            {
+                _playerNameAnnounceDelay -= Time.deltaTime;
+                if (_playerNameAnnounceDelay <= 0f)
+                {
+                    _playerNameAnnounceDelay = -1f;
+                    string matchup = _portraitNavigator.GetMatchupText();
+                    if (!string.IsNullOrEmpty(matchup))
+                    {
+                        MelonLogger.Msg($"[{NavigatorId}] Matchup: {matchup}");
+                        _announcer.Announce(matchup, Models.AnnouncementPriority.Normal);
+                    }
+                }
+            }
+
+            base.Update();
         }
 
         public override void OnSceneChanged(string sceneName)
@@ -137,6 +162,7 @@ namespace AccessibleArena.Core.Services
             {
                 _isWatching = false;
                 _hasCenteredMouse = false; // Reset for next duel
+                _playerNameAnnounceDelay = -1f;
                 _zoneNavigator.Deactivate();
                 _hotHighlightNavigator.Deactivate();
                 _battlefieldNavigator.Deactivate();

--- a/src/Core/Services/PlayerPortraitNavigator.cs
+++ b/src/Core/Services/PlayerPortraitNavigator.cs
@@ -545,6 +545,19 @@ namespace AccessibleArena.Core.Services
         }
 
         /// <summary>
+        /// Returns a matchup string for the current duel (e.g. "blindndangerous vs Opponent").
+        /// Returns null if either name is unavailable.
+        /// </summary>
+        public string GetMatchupText()
+        {
+            string local = GetPlayerUsername(false);
+            string opponent = GetPlayerUsername(true);
+            if (string.IsNullOrEmpty(local) || string.IsNullOrEmpty(opponent))
+                return null;
+            return $"{local} vs {opponent}";
+        }
+
+        /// <summary>
         /// Gets player username from PlayerNameView.
         /// </summary>
         private string GetPlayerUsername(bool isOpponent)


### PR DESCRIPTION
1.5 seconds after the duel HUD activates, announces the matchup as '[you] vs [opponent]' (e.g. 'blindndangerous vs Sparky'). The short delay allows the HUD to fully settle before names are read.

**Changes:**
- \PlayerPortraitNavigator.cs\: expose \GetMatchupText()\ public method
- \DuelNavigator.cs\: \_playerNameAnnounceDelay\ field + \Update()\ override to fire once after 1.5s; reset on scene change

**Tested:** Log confirms \lindndangerous vs Sparky\ announced correctly ~1.5s after duel activation.

---
AI-assisted implementation: GitHub Copilot (claude-sonnet-4.6)
Human testing/verification: blindndangerous