### PR TITLE
feat: announce opening hand list during mulligan

### DIFF
--- a/src/Core/Services/BrowserNavigator.cs
+++ b/src/Core/Services/BrowserNavigator.cs
@@ -1116,7 +1116,7 @@ namespace AccessibleArena.Core.Services
             {
                 message = GetAssignDamageEntryAnnouncement(cardCount, browserName);
             }
-            // Special announcement for London mulligan
+            // Special announcement for London mulligan (zone-based drag phase)
             else if (_browserInfo.IsLondon)
             {
                 var londonAnnouncement = _zoneNavigator.GetLondonEntryAnnouncement(cardCount);
@@ -1131,15 +1131,6 @@ namespace AccessibleArena.Core.Services
                 else
                 {
                     message = browserName;
-                }
-
-                // Schedule the hand card list as a delayed follow-up so the user can
-                // hear the main entry message and first-card focus before the list fires.
-                string handSummary = BuildHandSummary();
-                if (!string.IsNullOrEmpty(handSummary))
-                {
-                    _pendingHandSummary = handSummary;
-                    _handSummaryTimer = 1.5f;
                 }
             }
             // Special announcement for RepeatSelection (modal spell modes)
@@ -1171,6 +1162,18 @@ namespace AccessibleArena.Core.Services
             else
             {
                 message = browserName;
+            }
+
+            // Schedule delayed hand summary for the initial mulligan screen (BrowserTypeMulligan).
+            // Fires 1.5s after entry so the user hears the main message and first-card focus first.
+            if (_browserInfo.BrowserType == BrowserDetector.BrowserTypeMulligan)
+            {
+                string handSummary = BuildHandSummary();
+                if (!string.IsNullOrEmpty(handSummary))
+                {
+                    _pendingHandSummary = handSummary;
+                    _handSummaryTimer = 1.5f;
+                }
             }
 
             _announcer.Announce(message, AnnouncementPriority.High);


### PR DESCRIPTION
When the mulligan browser opens, announces the player's full opening hand as a delayed follow-up message.

**Format:** \Hand: Plains, Plains, Plains, Optimistic Scavenger, Sheltered by Ghosts, ...\

**Timing:** 1.5 seconds after the main entry message, so the user hears the entry prompt and first-card focus before the list fires.

**How it works:**
- Fires only for \BrowserTypeMulligan\ (the initial keep/mulligan decision screen)
- The zone-based drag phase (\BrowserTypeLondon\) does not trigger this
- Uses a timer in \BrowserNavigator.Update()\ — same pattern as player username announcement
- Timer is cleared in \ExitBrowserMode()\ so it can't fire after the screen closes

**Changes:**
- \BrowserNavigator.cs\: \_pendingHandSummary\/\_handSummaryTimer\ fields, timer tick in \Update()\, \BuildHandSummary()\ helper, scheduling in \AnnounceBrowserState()\ for Mulligan type, cleanup in \ExitBrowserMode()\

**Tested:** Hand: Plains, Plains, Plains, Optimistic Scavenger, Sheltered by Ghosts, Spellbook Vendor, Wonderweave Aerialist — announced 1.15s after entry.

---
AI-assisted implementation: GitHub Copilot (claude-sonnet-4.6)
Human testing/verification: blindndangerous