### PR TITLE
feat: phase-skip warning when passing with untapped lands

### DIFF
--- a/src/Core/Services/DuelAnnouncer.cs
+++ b/src/Core/Services/DuelAnnouncer.cs
@@ -73,6 +73,16 @@ namespace AccessibleArena.Core.Services
         public float TimeSinceLastPhaseChange => UnityEngine.Time.time - _lastPhaseChangeTime;
 
         /// <summary>
+        /// Returns the current phase string ("Main1", "Main2", "Combat", etc.).
+        /// </summary>
+        public string CurrentPhase => _currentPhase;
+
+        /// <summary>
+        /// Returns true if it is currently the local player's turn.
+        /// </summary>
+        public bool IsUserTurn => _isUserTurn;
+
+        /// <summary>
         /// Returns true if currently in Declare Attackers phase.
         /// </summary>
         public bool IsInDeclareAttackersPhase => _currentPhase == "Combat" && _currentStep == "DeclareAttack";

--- a/src/Core/Services/DuelNavigator.cs
+++ b/src/Core/Services/DuelNavigator.cs
@@ -90,6 +90,9 @@ namespace AccessibleArena.Core.Services
             // Connect HotHighlightNavigator to BattlefieldNavigator for syncing position on Tab
             _hotHighlightNavigator.SetBattlefieldNavigator(_battlefieldNavigator);
 
+            // Connect PriorityController to PhaseSkipGuard for phase skip warning
+            PhaseSkipGuard.SetPriorityController(_priorityController);
+
         }
 
         /// <summary>

--- a/src/Core/Services/HotHighlightNavigator.cs
+++ b/src/Core/Services/HotHighlightNavigator.cs
@@ -112,6 +112,7 @@ namespace AccessibleArena.Core.Services
             _lastItemZone = null;
             _lastPromptButtonText = null;
             _cachedAvatarViews.Clear();
+            PhaseSkipGuard.Reset();
             MelonLogger.Msg("[HotHighlightNavigator] Deactivated");
         }
 
@@ -264,7 +265,10 @@ namespace AccessibleArena.Core.Services
             }
 
             // Space - click primary button when no highlights are available,
-            // or when in selection mode (to submit the selection/discard)
+            // or when in selection mode (to submit the selection/discard).
+            // Phase skip warning is handled at Input.GetKeyDown level by PhaseSkipGuard via
+            // EventSystemPatch.GetKeyDown_Postfix — Space returns false while warning is pending,
+            // so this block simply won't execute on a blocked press.
             if (Input.GetKeyDown(KeyCode.Space))
             {
                 if (_items.Count == 0 || IsSelectionModeActive())
@@ -1266,6 +1270,7 @@ namespace AccessibleArena.Core.Services
             return true;
         }
 
+        /// <summary>
         #endregion
     }
 

--- a/src/Core/Services/PhaseSkipGuard.cs
+++ b/src/Core/Services/PhaseSkipGuard.cs
@@ -1,0 +1,149 @@
+using UnityEngine;
+using MelonLoader;
+using AccessibleArena.Core.Interfaces;
+using AccessibleArena.Core.Models;
+
+namespace AccessibleArena.Core.Services
+{
+    /// <summary>
+    /// Guards against accidental phase-skip when player has untapped lands in main phase.
+    ///
+    /// Intercepts at TWO levels:
+    /// 1. SendSubmitEventToSelectedObject prefix — blocks Unity EventSystem's Submit dispatch.
+    ///    This is the method that actually clicks the pass button. MTGA's input module may
+    ///    NOT use Input.GetButtonDown, so patching Input methods alone is insufficient.
+    /// 2. Input.GetKeyDown(Space) postfix — blocks KeyboardManager and direct callers.
+    ///
+    /// Uses release-tracking to prevent oscillation: after showing warning, blocks all
+    /// frames until Space is released. Next press after release confirms pass.
+    /// </summary>
+    public static class PhaseSkipGuard
+    {
+        private static bool _warningShown;
+        private static string _warningPhase;
+        private static bool _waitingForRelease;
+        private static bool _confirmed;       // Pass was confirmed — suppress until phase changes
+        private static string _confirmedPhase;
+        private static PriorityController _priorityController;
+
+        // Frame-cached decision so multiple calls per frame are consistent
+        private static int _lastDecisionFrame = -1;
+        private static bool _blockThisFrame;
+
+        public static void SetPriorityController(PriorityController pc) => _priorityController = pc;
+
+        /// <summary>
+        /// Called from SendSubmitEventToSelectedObject prefix and GetKeyDown postfix.
+        /// Returns true if Space should be blocked (warning shown or key still held).
+        /// Returns false if Space should pass through (not applicable, or confirming press).
+        /// </summary>
+        public static bool ShouldBlock()
+        {
+            // Cache decision per frame — called from multiple hooks
+            int frame = Time.frameCount;
+            if (frame == _lastDecisionFrame) return _blockThisFrame;
+            _lastDecisionFrame = frame;
+            _blockThisFrame = false;
+
+            // Track key release: once Space is released after warning, allow next press.
+            // Block on the release frame too — the confirm must be a NEW key-down.
+            if (_waitingForRelease)
+            {
+                if (!Input.GetKey(KeyCode.Space))
+                {
+                    _waitingForRelease = false;
+                    MelonLogger.Msg("[PhaseSkipGuard] Space released — next press will confirm");
+                }
+                // Block whether still held OR just released (require new press to confirm)
+                _blockThisFrame = true;
+                return true;
+            }
+
+            var duelAnnouncer = DuelAnnouncer.Instance;
+            if (duelAnnouncer == null) return false;
+
+            string phase = duelAnnouncer.CurrentPhase;
+
+            // After user confirmed pass, suppress until phase actually changes.
+            // The server takes ~200ms to process the pass — lands are still untapped
+            // during that window, which would re-trigger the warning.
+            if (_confirmed)
+            {
+                if (phase != _confirmedPhase)
+                    _confirmed = false; // Phase changed, allow future warnings
+                else
+                    return false; // Same phase, don't re-warn
+            }
+
+            // Auto-clear warning if phase changed since it was shown
+            if (_warningShown && phase != _warningPhase)
+            {
+                _warningShown = false;
+                _waitingForRelease = false;
+            }
+
+            if (phase != "Main1" && phase != "Main2") return false;
+            if (!duelAnnouncer.IsUserTurn) return false;
+
+            if (_warningShown)
+            {
+                // Second press after release — confirm pass, suppress re-evaluation
+                _warningShown = false;
+                _warningPhase = null;
+                _confirmed = true;
+                _confirmedPhase = phase;
+                MelonLogger.Msg("[PhaseSkipGuard] Confirmed — allowing pass");
+                return false;
+            }
+
+            if (!HasUntappedPlayerLands()) return false;
+
+            // Don't warn when full control is already active
+            if (_priorityController != null &&
+                (_priorityController.IsFullControlEnabled() || _priorityController.IsFullControlLocked()))
+                return false;
+
+            // First press with untapped lands — warn and block until released
+            _warningShown = true;
+            _warningPhase = phase;
+            _waitingForRelease = true;
+            _blockThisFrame = true;
+
+            var announcer = AccessibleArenaMod.Instance?.Announcer;
+            announcer?.Announce("Mana available. Press Space again to pass.", AnnouncementPriority.High);
+            MelonLogger.Msg("[PhaseSkipGuard] Warning shown — blocking until Space released and pressed again");
+            return true;
+        }
+
+        /// <summary>
+        /// Reset state on duel end or deactivation.
+        /// </summary>
+        public static void Reset()
+        {
+            _warningShown = false;
+            _warningPhase = null;
+            _waitingForRelease = false;
+            _confirmed = false;
+            _confirmedPhase = null;
+            _blockThisFrame = false;
+            _lastDecisionFrame = -1;
+        }
+
+        private static bool HasUntappedPlayerLands()
+        {
+            var battlefieldHolder = DuelHolderCache.GetHolder("BattlefieldCardHolder");
+            if (battlefieldHolder == null) return false;
+
+            foreach (Transform child in battlefieldHolder.GetComponentsInChildren<Transform>(true))
+            {
+                if (child == null || !child.gameObject.activeInHierarchy) continue;
+                var go = child.gameObject;
+                if (!CardDetector.IsCard(go)) continue;
+                var (_, isLand, isOpponent) = CardDetector.GetCardCategory(go);
+                if (!isLand || isOpponent) continue;
+                if (!CardStateProvider.GetIsTappedFromCard(go)) return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Patches/EventSystemPatch.cs
+++ b/src/Patches/EventSystemPatch.cs
@@ -135,12 +135,30 @@ namespace AccessibleArena.Patches
 
         /// <summary>
         /// Patch StandaloneInputModule.SendSubmitEventToSelectedObject to block Submit
-        /// when our navigator is on a toggle element or when in dropdown mode.
+        /// when our navigator is on a toggle element, when in dropdown mode,
+        /// or when PhaseSkipGuard is warning before passing priority.
+        ///
+        /// This is the critical interception point for phase-skip warning. MTGA's
+        /// input module may not call Input.GetButtonDown — it may use BaseInput or
+        /// a custom override — so patching Input methods alone is insufficient.
+        /// We must block here, where the actual submit dispatch happens.
+        ///
+        /// PhaseSkipGuard uses release-tracking to prevent oscillation: after showing
+        /// the warning, it blocks every frame until Space is released. The next press
+        /// after release confirms the pass.
         /// </summary>
         [HarmonyPatch(typeof(StandaloneInputModule), "SendSubmitEventToSelectedObject")]
         [HarmonyPrefix]
         public static bool SendSubmitEventToSelectedObject_Prefix()
         {
+            // Block Submit when PhaseSkipGuard wants to warn before passing.
+            // Input.GetKey(Space) distinguishes Space-triggered submit from Enter-triggered.
+            // ShouldBlock() is frame-cached and handles release-tracking internally.
+            if (Input.GetKey(KeyCode.Space) && PhaseSkipGuard.ShouldBlock())
+            {
+                return false;
+            }
+
             // Block Submit when we're on a toggle - our mod handles toggle activation directly
             if (InputManager.BlockSubmitForToggle)
             {
@@ -167,9 +185,8 @@ namespace AccessibleArena.Patches
 
         /// <summary>
         /// Patch Input.GetKeyDown to block Enter key when on a toggle or dropdown.
-        /// This catches MTGA code that directly reads Input.GetKeyDown(KeyCode.Return)
-        /// bypassing both KeyboardManager and EventSystem.
-        /// Sets EnterPressedWhileBlocked flag so our code can still detect the press.
+        /// Also blocks Space in DuelScene when PhaseSkipGuard is active, to prevent
+        /// KeyboardManager and direct callers from seeing Space.
         /// </summary>
         [HarmonyPatch(typeof(Input), nameof(Input.GetKeyDown), typeof(KeyCode))]
         [HarmonyPostfix]
@@ -182,6 +199,15 @@ namespace AccessibleArena.Patches
                 {
                     MelonLogger.Msg($"[EventSystemPatch] BLOCKED Input.GetKeyDown({key}) - on toggle/dropdown, setting EnterPressedWhileBlocked");
                     InputManager.EnterPressedWhileBlocked = true;
+                    __result = false;
+                }
+            }
+
+            // Block Space when PhaseSkipGuard is active (warning shown, waiting for release)
+            if (key == KeyCode.Space && __result)
+            {
+                if (PhaseSkipGuard.ShouldBlock())
+                {
                     __result = false;
                 }
             }

--- a/src/Patches/KeyboardManagerPatch.cs
+++ b/src/Patches/KeyboardManagerPatch.cs
@@ -151,6 +151,14 @@ namespace AccessibleArena.Patches
                 {
                     return true;
                 }
+                // Block Space when PhaseSkipGuard is warning (untapped lands in main phase).
+                // This prevents the game's keyboard subscriber from directly passing priority
+                // through a path that bypasses both EventSystem and Input.GetKeyDown.
+                if (key == KeyCode.Space && PhaseSkipGuard.ShouldBlock())
+                {
+                    MelonLogger.Msg("[KeyboardManagerPatch] Blocked Space — PhaseSkipGuard active");
+                    return true;
+                }
             }
 
             // In menu scenes, block Tab entirely - our mod handles Tab for navigation


### PR DESCRIPTION
## Summary

In main phases (Main1/Main2), if the player presses Space to pass priority while they have untapped lands, the mod now warns them first and requires a second Space press to confirm.

## Behavior

- Press Space with untapped lands in main phase: announces "Mana available. Press Space again to pass."
- Release Space, then press Space again: pass confirmed, phase advances normally
- No warning if full control (P) or locked full control (Shift+P) is active
- No warning outside of main phases or opponent's turn
- Works correctly with server round-trip latency (~200ms) — suppresses re-warning until phase actually changes

## Implementation

New file: src/Core/Services/PhaseSkipGuard.cs
- Frame-cached interception at three levels to block Space from all game paths:
  1. KeyboardManagerPatch.ShouldBlockKey() — blocks the game's keyboard subscriber (the actual path sending pass-priority actions server-side)
  2. EventSystemPatch.SendSubmitEventToSelectedObject prefix — blocks Unity EventSystem Submit dispatch
  3. EventSystemPatch.GetKeyDown_Postfix — blocks direct Input.GetKeyDown callers
- Release-tracking: blocks until Space is physically released, then requires a new key-down to confirm
- Confirmed-phase suppression: after confirming, stays silent until phase changes (prevents re-warning during server RTT window)

Modified files:
- DuelAnnouncer.cs: added CurrentPhase and IsUserTurn public properties
- DuelNavigator.cs: wires PriorityController into PhaseSkipGuard
- HotHighlightNavigator.cs: cleaned up Space handler
- EventSystemPatch.cs: added PhaseSkipGuard.ShouldBlock() to SendSubmitEventToSelectedObject prefix and GetKeyDown_Postfix
- KeyboardManagerPatch.cs: added Space blocking when PhaseSkipGuard.ShouldBlock() is true in DuelScene

---

AI-assisted implementation: Claude Opus 4.6
Human testing/verification: blindndangerous