### PR TITLE
fix: allow repeated L presses to re-announce life totals

### DIFF
--- a/src/Core/Services/PlayerPortraitNavigator.cs
+++ b/src/Core/Services/PlayerPortraitNavigator.cs
@@ -861,7 +861,8 @@ namespace AccessibleArena.Core.Services
                 announcement = "Life totals not available";
             }
 
-            _announcer.Announce(announcement, AnnouncementPriority.Normal);
+            // High priority so repeated L presses always re-announce (bypasses duplicate suppression)
+            _announcer.Announce(announcement, AnnouncementPriority.High);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes repeated L presses not re-announcing life totals.

## Root Cause

`AnnouncementService.Announce()` silently drops any message that matches `_lastAnnouncement` when priority is below `High`. Life totals are static (don't change between presses), so every press after the first was silently swallowed.

## Fix

Changed `AnnounceLifeTotals()` to use `AnnouncementPriority.High`. Since pressing L is a deliberate user query — not a passive notification — it should always re-speak, regardless of what was last announced.

## Behavior

- Press L: "You 20 life. Opponent 17 life."
- Press L again immediately: re-announces, no need to press another key first
- Consistent with how other explicit query shortcuts work (T for turn, V for player info, etc.)

---

AI-assisted implementation: Claude Sonnet 4.6
Human testing/verification: blindndangerous