### PR TITLE
polish: remove verbose keybindings hint from duel startup message

### DIFF
--- a/src/Core/Services/DuelNavigator.cs
+++ b/src/Core/Services/DuelNavigator.cs
@@ -331,8 +331,7 @@ namespace AccessibleArena.Core.Services
         {
             int handCards = _zoneNavigator.HandCardCount;
 
-            string core = Models.Strings.Duel_Started(handCards);
-            return Strings.WithHint(core, "DuelKeybindingsHint");
+            return Models.Strings.Duel_Started(handCards);
         }
 
         protected override bool OnElementActivated(int index, GameObject element)


### PR DESCRIPTION
## Summary

Removes the long keybindings hint appended to the duel startup announcement.

## Problem

Every time a match starts, the announcement was:
> Duel started. N cards in hand. Tab cycles playable cards. C for hand. B for your creatures, A for your lands, R for your non-creatures. Shift plus B, A, R for enemy. G for graveyard, X for exile, S for stack. V for player info. P for full control, Shift plus P to lock. Number keys 1 to 0 for phase stops

This is very long and repetitive for experienced players — the same information is already available in the F1 help menu.

## Fix

Return only the brief core message: **'Duel started. N cards in hand'**

The full keybindings reference remains accessible via F1.

---

AI-assisted implementation: Claude Sonnet 4.6
Human testing/verification: blindndangerous