### PR TITLE
fix: suppress duplicate graveyard zone count announcement

### DIFF
--- a/src/Core/Services/DuelAnnouncer.cs
+++ b/src/Core/Services/DuelAnnouncer.cs
@@ -507,7 +507,9 @@ namespace AccessibleArena.Core.Services
                 }
                 else if (zoneName == "Graveyard" && diff > 0)
                 {
-                    return isOpponent ? Strings.Duel_CardToOpponentGraveyard : Strings.Duel_CardToYourGraveyard;
+                    // Suppress generic "card to graveyard" — ZoneTransferGroup fires with the specific
+                    // card name and reason (died, destroyed, discarded, etc.) which is more informative.
+                    // We still track the count above for dirty-marking navigators.
                 }
                 else if (zoneName == "Stack")
                 {


### PR DESCRIPTION
## Summary

Removes a redundant 'Card went to your/opponent's graveyard' announcement that fired alongside the more specific card-named announcement.

## Problem

When a card entered the graveyard, two announcements fired for the same event:
1. **Generic (UpdateZoneUXEvent):** 'Card went to your graveyard'
2. **Specific (ZoneTransferGroup):** 'Lightning Strike died' / 'Lightning Strike discarded' etc.

The generic message added noise without adding information.

## Fix

Suppress the generic graveyard announcement in the zone count handler. Zone count tracking and navigator dirty-marking are preserved — only the redundant string return is removed. The specific ZoneTransferGroup announcement remains and covers all cases (Died, Destroyed, Sacrificed, Countered, Discarded, Milled).

---

AI-assisted implementation: Claude Sonnet 4.6
Human testing/verification: blindndangerous