### PR TITLE
docs: update CHANGELOG for v0.8.6 (PRs 25-28)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,28 @@
 
 All notable changes to Accessible Arena.
 
+# Changelog
+
+All notable changes to Accessible Arena.
+
 ## v0.8.6
+
+### Fix: Phase-skip warning before passing priority with untapped lands (PR #25)
+- When in Main Phase 1 or 2 with untapped lands and full control is off, pressing Space now warns "You have untapped lands. Press Space again to pass priority."
+- A second Space press confirms and passes as normal.
+- Warning is suppressed during full control mode (locked or temporary).
+
+### Fix: Repeated L press now re-announces life totals (PR #26)
+- Pressing L multiple times in a row now always reads life totals, even when they haven't changed between presses.
+
+### Polish: Duel startup announcement is now brief (PR #27)
+- Removed the long keybindings hint from the duel start announcement.
+- Now says only "Duel started. N cards in hand."
+- Full keybindings reference remains accessible via F1.
+
+### Fix: Duplicate graveyard announcement suppressed (PR #28)
+- When a creature died or a card was discarded, two announcements fired: a generic "Card went to your graveyard" and the specific "Lightning Strike died."
+- Generic announcement removed; only the specific named announcement now plays.
 
 ## v0.8.5
 


### PR DESCRIPTION
## Summary

Adds CHANGELOG entries for the four v0.8.6 fixes submitted in this session:

- PR #25: Phase-skip warning before passing priority with untapped lands
- PR #26: Repeated L press re-announces life totals
- PR #27: Brief duel startup announcement (no long keybindings hint)
- PR #28: Suppress duplicate graveyard zone count announcement

No code changes.

---

AI-assisted implementation: Claude Sonnet 4.6
Human testing/verification: blindndangerous