### PR TITLE
polish: add P/T, counters, and summoning sickness to battlefield card announcements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -80,6 +80,12 @@ All notable changes to Accessible Arena.
 - All 12 language files updated.
 - The F1 help menu already had the correct descriptions ("Enter: Toggle card between zones", "Space: Confirm selection"); only the entry announcement was wrong.
 
+### Polish: Battlefield cards now announce P/T, counters, and summoning sickness (PR #33)
+- Creature cards now include power/toughness in the announcement (e.g. "Grizzly Bears 2/2, can attack, 1 of 5")
+- Nonzero counters are listed after P/T (e.g. "2 +1/+1 counters, 1 Oil counter")
+- Planeswalker loyalty appears via the Loyalty counter (e.g. "4 Loyalty counters")
+- Creatures that entered this turn now explicitly say "summoning sickness" when no other combat state applies
+
 ## v0.8.5
 
 ### Fix: Stale browser announcement after confirming modal spell mode

--- a/lang/de.json
+++ b/lang/de.json
@@ -646,6 +646,7 @@
   "Combat_SelectedToBlock": "zum Blocken ausgewählt",
   "Combat_CanBlock": "kann blocken",
   "Combat_Tapped": "getappt",
+  "Combat_SummoningSickness": "Beschwörungskrankheit",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "zugewiesen",
   "Target_Targeted_Format": "{0} anvisiert",

--- a/lang/en.json
+++ b/lang/en.json
@@ -648,6 +648,7 @@
   "Combat_SelectedToBlock": "selected to block",
   "Combat_CanBlock": "can block",
   "Combat_Tapped": "tapped",
+  "Combat_SummoningSickness": "summoning sickness",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "assigned",
   "Target_Targeted_Format": "Targeted {0}",

--- a/lang/es.json
+++ b/lang/es.json
@@ -635,6 +635,7 @@
   "Combat_SelectedToBlock": "seleccionado para bloquear",
   "Combat_CanBlock": "puede bloquear",
   "Combat_Tapped": "girada",
+  "Combat_SummoningSickness": "mareo de convocación",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "asignado",
   "Target_Targeted_Format": "{0} seleccionado como objetivo",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -635,6 +635,7 @@
   "Combat_SelectedToBlock": "sélectionné pour bloquer",
   "Combat_CanBlock": "peut bloquer",
   "Combat_Tapped": "engagé",
+  "Combat_SummoningSickness": "mal d'invocation",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "assigné",
   "Target_Targeted_Format": "{0} ciblé",

--- a/lang/it.json
+++ b/lang/it.json
@@ -635,6 +635,7 @@
   "Combat_SelectedToBlock": "selezionato per bloccare",
   "Combat_CanBlock": "può bloccare",
   "Combat_Tapped": "tappata",
+  "Combat_SummoningSickness": "malattia da evocazione",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "assegnato",
   "Target_Targeted_Format": "{0} bersagliato",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -635,6 +635,7 @@
   "Combat_SelectedToBlock": "ブロックに選択済み",
   "Combat_CanBlock": "ブロック可能",
   "Combat_Tapped": "タップ状態",
+  "Combat_SummoningSickness": "召喚酔い",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "割り当て済み",
   "Target_Targeted_Format": "{0}を対象にした",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -635,6 +635,7 @@
   "Combat_SelectedToBlock": "방어용으로 선택됨",
   "Combat_CanBlock": "방어 가능",
   "Combat_Tapped": "탭됨",
+  "Combat_SummoningSickness": "소환 멀미",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "배정됨",
   "Target_Targeted_Format": "{0} 대상 지정",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -635,6 +635,7 @@
   "Combat_SelectedToBlock": "wybrany do blokowania",
   "Combat_CanBlock": "może blokować",
   "Combat_Tapped": "odwrócony",
+  "Combat_SummoningSickness": "choroba przywołania",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "przypisany",
   "Target_Targeted_Format": "{0} obrany jako cel",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -635,6 +635,7 @@
   "Combat_SelectedToBlock": "selecionado para bloquear",
   "Combat_CanBlock": "pode bloquear",
   "Combat_Tapped": "virada",
+  "Combat_SummoningSickness": "tontura de invocação",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "atribuído",
   "Target_Targeted_Format": "{0} alvejado",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -635,6 +635,7 @@
   "Combat_SelectedToBlock": "выбрано для блока",
   "Combat_CanBlock": "может блокировать",
   "Combat_Tapped": "повёрнуто",
+  "Combat_SummoningSickness": "болезнь призыва",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "назначен",
   "Target_Targeted_Format": "{0} взят на прицел",

--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -635,6 +635,7 @@
   "Combat_SelectedToBlock": "已选择阻挡",
   "Combat_CanBlock": "可以阻挡",
   "Combat_Tapped": "已横置",
+  "Combat_SummoningSickness": "召唤倦怠",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "已分配",
   "Target_Targeted_Format": "已指定{0}为目标",

--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -635,6 +635,7 @@
   "Combat_SelectedToBlock": "已選擇阻擋",
   "Combat_CanBlock": "可以阻擋",
   "Combat_Tapped": "已橫置",
+  "Combat_SummoningSickness": "召喚倦怠",
   "Combat_PTBlocking_Format": "{0}/{1}",
   "Combat_Assigned": "已分配",
   "Target_Targeted_Format": "已指定{0}為目標",

--- a/src/Core/Models/Strings.cs
+++ b/src/Core/Models/Strings.cs
@@ -267,6 +267,7 @@ namespace AccessibleArena.Core.Models
         public static string Combat_SelectedToBlock => L.Get("Combat_SelectedToBlock");
         public static string Combat_CanBlock => L.Get("Combat_CanBlock");
         public static string Combat_Tapped => L.Get("Combat_Tapped");
+        public static string Combat_SummoningSickness => L.Get("Combat_SummoningSickness");
         public static string Combat_PTBlocking(int power, int toughness) => L.Format("Combat_PTBlocking_Format", power, toughness);
         public static string Combat_Assigned => L.Get("Combat_Assigned");
 

--- a/src/Core/Services/BattlefieldNavigator.cs
+++ b/src/Core/Services/BattlefieldNavigator.cs
@@ -675,12 +675,20 @@ namespace AccessibleArena.Core.Services
             if (_currentIndex >= cards.Count) return;
 
             var card = cards[_currentIndex];
-            string cardName = CardDetector.GetCardName(card);
+
+            // Get full card info (name + P/T) in one call — GetCardName already calls this internally
+            var info = CardDetector.ExtractCardInfo(card);
+            string cardName = info.Name ?? "Unknown card";
+            string statSuffix = !string.IsNullOrEmpty(info.PowerToughness) ? $" {info.PowerToughness}" : "";
+
             int position = _currentIndex + 1;
             int total = cards.Count;
 
             // Add combat state if available
             string combatState = _combatNavigator?.GetCombatStateText(card) ?? "";
+
+            // Add nonzero counter info (e.g. ", 2 +1/+1 counters")
+            string counterText = BuildCounterText(CardStateProvider.GetCountersFromCard(card));
 
             // Add attachment info (enchantments, equipment attached to this card)
             string attachmentText = CardStateProvider.GetAttachmentText(card);
@@ -689,7 +697,7 @@ namespace AccessibleArena.Core.Services
             string targetingText = CardStateProvider.GetTargetingText(card);
 
             string prefix = includeRowName ? $"{GetRowName(_currentRow)}, " : "";
-            _announcer.Announce($"{prefix}{cardName}{combatState}{attachmentText}{targetingText}, {position} of {total}", priority);
+            _announcer.Announce($"{prefix}{cardName}{statSuffix}{counterText}{combatState}{attachmentText}{targetingText}, {position} of {total}", priority);
 
             // Set EventSystem focus to the card - this ensures other navigators
             // (like PlayerPortrait) detect the focus change and exit their modes
@@ -704,6 +712,22 @@ namespace AccessibleArena.Core.Services
             {
                 cardNavigator.PrepareForCard(card, ZoneType.Battlefield);
             }
+        }
+
+        /// <summary>
+        /// Builds a compact counter text string for nonzero counters, e.g. ", 2 +1/+1 counters, 1 Oil counter".
+        /// Returns empty string if there are no counters.
+        /// </summary>
+        private static string BuildCounterText(List<(string typeName, int count)> counters)
+        {
+            if (counters == null || counters.Count == 0) return "";
+            var parts = new System.Text.StringBuilder();
+            foreach (var (typeName, count) in counters)
+            {
+                parts.Append($", {count} {typeName} counter");
+                if (count != 1) parts.Append('s');
+            }
+            return parts.ToString();
         }
 
         /// <summary>

--- a/src/Core/Services/CombatNavigator.cs
+++ b/src/Core/Services/CombatNavigator.cs
@@ -453,6 +453,10 @@ namespace AccessibleArena.Core.Services
             if (isTapped && !isAttacking)
                 states.Add(Models.Strings.Combat_Tapped);
 
+            // Summoning sickness: creature entered this turn and cannot yet attack
+            if (states.Count == 0 && CardStateProvider.IsCreatureCard(card) && CardStateProvider.GetHasSummoningSicknessFromCard(card))
+                states.Add(Models.Strings.Combat_SummoningSickness);
+
             if (states.Count == 0)
                 return "";
 


### PR DESCRIPTION
## Summary
Battlefield card announcements now include Power/Toughness, counters, and summoning sickness.

Before: 'Grizzly Bears, can attack, 1 of 5'
After: 'Grizzly Bears 2/2, can attack, 1 of 5'

## What changed
- \BattlefieldNavigator.AnnounceCurrentCard()\: appends P/T for creatures; appends counter text (nonzero counters only)
- \CombatNavigator.GetCombatStateText()\: appends 'summoning sickness' when creature entered this turn and has no other combat state
- \Strings.cs\: added \Combat_SummoningSickness\
- All 12 lang files: added \Combat_SummoningSickness\

## Testing
- [x] P/T announced on creature cards: 'Optimistic Scavenger 10/8' confirmed
- [x] Counters announced: '3 +1/+1 counters' confirmed
- [x] Summoning sickness announced: 'Malakir Cullblade 1/1, summoning sickness' confirmed (prior session)
- [ ] Planeswalker loyalty counter (untested)
- [ ] Non-creature (no P/T shown) (untested)

---
AI-assisted implementation: GitHub Copilot (claude-sonnet-4.6)
Human testing/verification: blindndangerous