### PR TITLE
fix: zone/row shortcut keys always re-announce when pressed again

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -80,6 +80,11 @@ All notable changes to Accessible Arena.
 - All 12 language files updated.
 - The F1 help menu already had the correct descriptions ("Enter: Toggle card between zones", "Space: Confirm selection"); only the entry announcement was wrong.
 
+### Fix: Zone/row shortcuts always re-announce when pressed again (PR #34)
+- Pressing C, B, G, X, S, W (and Shift variants) now always announces the current card/zone even if content hasn't changed
+- Pressing Shift+C now always announces opponent hand count
+- Previously, a second keypress within the same zone was silently dropped
+
 ## v0.8.5
 
 ### Fix: Stale browser announcement after confirming modal spell mode

--- a/src/Core/Services/BattlefieldNavigator.cs
+++ b/src/Core/Services/BattlefieldNavigator.cs
@@ -387,7 +387,8 @@ namespace AccessibleArena.Core.Services
             _currentRow = row;
             _currentIndex = 0;
 
-            AnnounceCurrentCard(includeRowName: true);
+            // High priority: user explicitly pressed a row shortcut — always re-announce
+            AnnounceCurrentCard(includeRowName: true, priority: AnnouncementPriority.High);
         }
 
         /// <summary>

--- a/src/Core/Services/ZoneNavigator.cs
+++ b/src/Core/Services/ZoneNavigator.cs
@@ -609,7 +609,8 @@ namespace AccessibleArena.Core.Services
             }
             else
             {
-                AnnounceCurrentCard(includeZoneName: true);
+                // High priority: user explicitly pressed a zone shortcut — always re-announce
+                AnnounceCurrentCard(includeZoneName: true, priority: AnnouncementPriority.High);
             }
         }
 
@@ -1054,7 +1055,8 @@ namespace AccessibleArena.Core.Services
             int count = GetZoneCardCount(ZoneType.OpponentHand);
             if (count >= 0)
             {
-                _announcer.Announce(Strings.OpponentHandCount(count), AnnouncementPriority.Normal);
+                // High priority: user explicitly pressed Shift+C — always re-announce
+                _announcer.Announce(Strings.OpponentHandCount(count), AnnouncementPriority.High);
             }
             else
             {


### PR DESCRIPTION
## Problem
Zone and battlefield shortcut keys (C, G, X, S, W, B, A, R and Shift variants) silently skipped the announcement when pressed a second time, because \AnnouncementService\ suppresses duplicate messages at Normal priority.

## Fix
Use \High\ priority for explicit user re-reads to bypass duplicate suppression. Applied to:
- \ZoneNavigator.NavigateToZone\ — covers C, G, Shift+G, X, Shift+X, S, W
- \ZoneNavigator.AnnounceOpponentHandCount\ — covers Shift+C
- \BattlefieldNavigator.NavigateToRow\ — covers B, Shift+B, A, Shift+A, R, Shift+R

## Testing
- [x] Zone shortcuts re-announce on repeated press — confirmed by blindndangerous
- [x] Battlefield row shortcuts re-announce on repeated press — confirmed
- [x] Normal Left/Right navigation unaffected

---
AI-assisted implementation: GitHub Copilot (claude-sonnet-4.6)
Human testing/verification: blindndangerous