### PR TITLE
fix: repeat-announce single card on Left/Right when zone has 1 item

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Accessible Arena.
 
+## v0.8.7-dev
+
+### Fix: Single-item zones repeat on Left/Right (PR #36)
+- When a zone or battlefield row contains exactly one card, pressing Left or Right now re-announces that card instead of saying "end" or "beginning".
+- Applies to all zones (Hand, Graveyard, Exile, Stack, Command) and all battlefield rows.
+- Opponent hand count (Shift+C) is unaffected as it announces a count, not a card.
+
 ## v0.8.6
 
 ### Best of 3 (Bo3) Support
@@ -79,6 +86,10 @@ All notable changes to Accessible Arena.
 - Corrected to "Enter to toggle to bottom, Space to confirm" (Scry) and "Enter to toggle to graveyard, Space to confirm" (Surveil).
 - All 12 language files updated.
 - The F1 help menu already had the correct descriptions ("Enter: Toggle card between zones", "Space: Confirm selection"); only the entry announcement was wrong.
+
+### Fix: Single-item zones/rows repeat on Left/Right (PR #36)
+- When a zone or battlefield row contains exactly one card, pressing Left or Right now re-announces that card instead of saying "end" or "beginning"
+- Applies to all zones (Hand, Graveyard, Exile, Stack, Command) and all battlefield rows
 
 ## v0.8.5
 

--- a/src/Core/Services/BattlefieldNavigator.cs
+++ b/src/Core/Services/BattlefieldNavigator.cs
@@ -464,6 +464,12 @@ namespace AccessibleArena.Core.Services
                 return;
             }
 
+            if (cards.Count == 1)
+            {
+                AnnounceCurrentCard(priority: AnnouncementPriority.High);
+                return;
+            }
+
             if (_currentIndex < cards.Count - 1)
             {
                 _currentIndex++;
@@ -484,6 +490,12 @@ namespace AccessibleArena.Core.Services
             if (cards.Count == 0)
             {
                 _announcer.AnnounceInterrupt(Strings.RowEmpty(GetRowName(_currentRow)));
+                return;
+            }
+
+            if (cards.Count == 1)
+            {
+                AnnounceCurrentCard(priority: AnnouncementPriority.High);
                 return;
             }
 

--- a/src/Core/Services/ZoneNavigator.cs
+++ b/src/Core/Services/ZoneNavigator.cs
@@ -656,6 +656,12 @@ namespace AccessibleArena.Core.Services
             var zoneInfo = _zones[_currentZone];
             if (zoneInfo.Cards.Count == 0) return;
 
+            if (zoneInfo.Cards.Count == 1)
+            {
+                AnnounceCurrentCard(priority: AnnouncementPriority.High);
+                return;
+            }
+
             if (_cardIndexInZone < zoneInfo.Cards.Count - 1)
             {
                 _cardIndexInZone++;
@@ -677,6 +683,12 @@ namespace AccessibleArena.Core.Services
 
             var zoneInfo = _zones[_currentZone];
             if (zoneInfo.Cards.Count == 0) return;
+
+            if (zoneInfo.Cards.Count == 1)
+            {
+                AnnounceCurrentCard(priority: AnnouncementPriority.High);
+                return;
+            }
 
             if (_cardIndexInZone > 0)
             {


### PR DESCRIPTION
## Problem
When a zone or battlefield row contains exactly one card, pressing Left or Right said 'end' or 'beginning' with no card information. The user had no way to re-read the card without pressing the zone shortcut again.

## Fix
In \ZoneNavigator.NextCard/PreviousCard\ and \BattlefieldNavigator.NextCard/PreviousCard\: when \cards.Count == 1\, re-announce the current card at High priority instead of saying end/beginning.

- Left/Right in a zone with 1 card: repeats 'Card Name, 1 of 1'
- Left/Right in a battlefield row with 1 card: repeats 'Card Name, 1 of 1'
- Multi-card zones: unchanged — boundary still says end/beginning
- Opponent hand count (Shift+C): unaffected — count-only, not card navigation

## Testing
- [x] Zone with 1 card — Left and Right both re-read the card: log shows 'Veteran Survivor, 1 of 1' announced three times consecutively after hand dropped to 1 card
- [x] Normal multi-card boundary behavior unaffected — confirmed

---
AI-assisted implementation: GitHub Copilot (claude-sonnet-4.6)
Human testing/verification: blindndangerous