### PR TITLE
fix: localize hardcoded "vs" in duel matchup announcement

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -670,6 +670,7 @@
   "Card_TargetedBy_Two_Format": "Ziel von {0} und {1}",
   "Card_TargetedBy_Many_Format": "Ziel von {0}",
   "Duel_Started": "Duell gestartet",
+  "Duel_Matchup_Format": "{0} vs. {1}",
   "Duel_YourTurn_Format": "Zug {0}",
   "Duel_OpponentTurn": "Zug des Gegners",
   "Duel_TurnChanged": "Zugwechsel",

--- a/lang/en.json
+++ b/lang/en.json
@@ -672,6 +672,7 @@
   "Card_TargetedBy_Two_Format": "targeted by {0} and {1}",
   "Card_TargetedBy_Many_Format": "targeted by {0}",
   "Duel_Started": "Duel started",
+  "Duel_Matchup_Format": "{0} vs {1}",
   "Duel_YourTurn_Format": "Turn {0}",
   "Duel_OpponentTurn": "Opponent's turn",
   "Duel_TurnChanged": "Turn changed",

--- a/lang/es.json
+++ b/lang/es.json
@@ -659,6 +659,7 @@
   "Card_TargetedBy_Two_Format": "objetivo de {0} y {1}",
   "Card_TargetedBy_Many_Format": "objetivo de {0}",
   "Duel_Started": "Duelo iniciado",
+  "Duel_Matchup_Format": "{0} vs {1}",
   "Duel_YourTurn_Format": "Turno {0}",
   "Duel_OpponentTurn": "Turno del oponente",
   "Duel_TurnChanged": "Cambio de turno",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -659,6 +659,7 @@
   "Card_TargetedBy_Two_Format": "ciblé par {0} et {1}",
   "Card_TargetedBy_Many_Format": "ciblé par {0}",
   "Duel_Started": "Duel commencé",
+  "Duel_Matchup_Format": "{0} contre {1}",
   "Duel_YourTurn_Format": "Tour {0}",
   "Duel_OpponentTurn": "Tour de l'adversaire",
   "Duel_TurnChanged": "Changement de tour",

--- a/lang/it.json
+++ b/lang/it.json
@@ -659,6 +659,7 @@
   "Card_TargetedBy_Two_Format": "bersaglio di {0} e {1}",
   "Card_TargetedBy_Many_Format": "bersaglio di {0}",
   "Duel_Started": "Duello iniziato",
+  "Duel_Matchup_Format": "{0} vs {1}",
   "Duel_YourTurn_Format": "Turno {0}",
   "Duel_OpponentTurn": "Turno dell'avversario",
   "Duel_TurnChanged": "Cambio turno",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -659,6 +659,7 @@
   "Card_TargetedBy_Two_Format": "{0}と{1}の対象",
   "Card_TargetedBy_Many_Format": "{0}の対象",
   "Duel_Started": "デュエル開始",
+  "Duel_Matchup_Format": "{0} vs {1}",
   "Duel_YourTurn_Format": "ターン{0}",
   "Duel_OpponentTurn": "対戦相手のターン",
   "Duel_TurnChanged": "ターン変更",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -659,6 +659,7 @@
   "Card_TargetedBy_Two_Format": "{0}과(와) {1}의 대상",
   "Card_TargetedBy_Many_Format": "{0}의 대상",
   "Duel_Started": "대전 시작",
+  "Duel_Matchup_Format": "{0} vs {1}",
   "Duel_YourTurn_Format": "턴 {0}",
   "Duel_OpponentTurn": "상대의 턴",
   "Duel_TurnChanged": "턴 변경",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -659,6 +659,7 @@
   "Card_TargetedBy_Two_Format": "cel {0} i {1}",
   "Card_TargetedBy_Many_Format": "cel {0}",
   "Duel_Started": "Pojedynek rozpoczęty",
+  "Duel_Matchup_Format": "{0} kontra {1}",
   "Duel_YourTurn_Format": "Tura {0}",
   "Duel_OpponentTurn": "Tura przeciwnika",
   "Duel_TurnChanged": "Zmiana tury",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -659,6 +659,7 @@
   "Card_TargetedBy_Two_Format": "alvo de {0} e {1}",
   "Card_TargetedBy_Many_Format": "alvo de {0}",
   "Duel_Started": "Duelo iniciado",
+  "Duel_Matchup_Format": "{0} vs {1}",
   "Duel_YourTurn_Format": "Turno {0}",
   "Duel_OpponentTurn": "Turno do oponente",
   "Duel_TurnChanged": "Mudança de turno",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -659,6 +659,7 @@
   "Card_TargetedBy_Two_Format": "цель {0} и {1}",
   "Card_TargetedBy_Many_Format": "цель {0}",
   "Duel_Started": "Дуэль началась",
+  "Duel_Matchup_Format": "{0} против {1}",
   "Duel_YourTurn_Format": "Ход {0}",
   "Duel_OpponentTurn": "Ход оппонента",
   "Duel_TurnChanged": "Смена хода",

--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -659,6 +659,7 @@
   "Card_TargetedBy_Two_Format": "被{0}和{1}指定为目标",
   "Card_TargetedBy_Many_Format": "被{0}指定为目标",
   "Duel_Started": "对决开始",
+  "Duel_Matchup_Format": "{0} 对战 {1}",
   "Duel_YourTurn_Format": "回合{0}",
   "Duel_OpponentTurn": "对手的回合",
   "Duel_TurnChanged": "回合变更",

--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -659,6 +659,7 @@
   "Card_TargetedBy_Two_Format": "被{0}和{1}指定為目標",
   "Card_TargetedBy_Many_Format": "被{0}指定為目標",
   "Duel_Started": "對決開始",
+  "Duel_Matchup_Format": "{0} 對戰 {1}",
   "Duel_YourTurn_Format": "回合{0}",
   "Duel_OpponentTurn": "對手的回合",
   "Duel_TurnChanged": "回合變更",

--- a/src/Core/Models/Strings.cs
+++ b/src/Core/Models/Strings.cs
@@ -290,6 +290,7 @@ namespace AccessibleArena.Core.Models
         // DUEL ANNOUNCEMENTS
         // ===========================================
         public static string Duel_Started => L.Get("Duel_Started");
+        public static string Duel_Matchup(string a, string b) => L.Format("Duel_Matchup_Format", a, b);
         public static string Duel_YourTurn(int turnNum) => L.Format("Duel_YourTurn_Format", turnNum);
         public static string Duel_OpponentTurn => L.Get("Duel_OpponentTurn");
         public static string Duel_TurnChanged => L.Get("Duel_TurnChanged");

--- a/src/Core/Services/PlayerPortraitNavigator.cs
+++ b/src/Core/Services/PlayerPortraitNavigator.cs
@@ -582,7 +582,7 @@ namespace AccessibleArena.Core.Services
             string opponent = GetPlayerUsername(true);
             if (string.IsNullOrEmpty(local) || string.IsNullOrEmpty(opponent))
                 return null;
-            return $"{local} vs {opponent}";
+            return Strings.Duel_Matchup(local, opponent);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Adds `Duel_Matchup_Format` key to all 12 locale files with language-appropriate translations (contre, kontra, против, 対戦, 對戰, vs., vs)
- Adds `Strings.Duel_Matchup(string a, string b)` to `Strings.cs`
- Updates `PlayerPortraitNavigator.GetMatchupText()` to use `Strings.Duel_Matchup()` instead of the hardcoded `$"{local} vs {opponent}"` string interpolation

---
Co-Authored-By: Claude Sonnet 4.6 <claude[bot]@users.noreply.github.com>