### PR TITLE
fix: localize hardcoded "New Deck" label in UITextExtractor

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -29,6 +29,7 @@
   "ClosingSettings": "Einstellungen werden geschlossen",
   "ClosingPlayBlade": "Spielmenü wird geschlossen",
   "ExitingDeckBuilder": "Deck-Editor wird verlassen",
+  "NewDeck": "Neues Deck",
   "DeckInfoCardCount": "Kartenanzahl",
   "DeckInfoManaCurve": "Manakurve",
   "DeckInfoTypeBreakdown": "Typen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -29,6 +29,7 @@
   "ClosingSettings": "Closing settings",
   "ClosingPlayBlade": "Closing play menu",
   "ExitingDeckBuilder": "Exiting deck builder",
+  "NewDeck": "New Deck",
   "DeckInfoCardCount": "Card Count",
   "DeckInfoManaCurve": "Mana Curve",
   "DeckInfoTypeBreakdown": "Types",

--- a/lang/es.json
+++ b/lang/es.json
@@ -29,6 +29,7 @@
   "ClosingSettings": "Cerrando ajustes",
   "ClosingPlayBlade": "Cerrando menú de juego",
   "ExitingDeckBuilder": "Saliendo del constructor de mazos",
+  "NewDeck": "Nuevo mazo",
   "DeckInfoCardCount": "Número de cartas",
   "DeckInfoManaCurve": "Curva de maná",
   "DeckInfoTypeBreakdown": "Tipos",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -29,6 +29,7 @@
   "ClosingSettings": "Fermeture des paramètres",
   "ClosingPlayBlade": "Fermeture du menu de jeu",
   "ExitingDeckBuilder": "Sortie du constructeur de deck",
+  "NewDeck": "Nouveau deck",
   "DeckInfoCardCount": "Nombre de cartes",
   "DeckInfoManaCurve": "Courbe de mana",
   "DeckInfoTypeBreakdown": "Types",

--- a/lang/it.json
+++ b/lang/it.json
@@ -29,6 +29,7 @@
   "ClosingSettings": "Chiusura impostazioni",
   "ClosingPlayBlade": "Chiusura menu di gioco",
   "ExitingDeckBuilder": "Uscita dal costruttore di mazzi",
+  "NewDeck": "Nuovo mazzo",
   "DeckInfoCardCount": "Numero carte",
   "DeckInfoManaCurve": "Curva di mana",
   "DeckInfoTypeBreakdown": "Tipi",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -29,6 +29,7 @@
   "ClosingSettings": "設定を閉じています",
   "ClosingPlayBlade": "プレイメニューを閉じています",
   "ExitingDeckBuilder": "デッキビルダーを終了しています",
+  "NewDeck": "新しいデッキ",
   "DeckInfoCardCount": "カード枚数",
   "DeckInfoManaCurve": "マナカーブ",
   "DeckInfoTypeBreakdown": "タイプ",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -29,6 +29,7 @@
   "ClosingSettings": "설정을 닫는 중",
   "ClosingPlayBlade": "플레이 메뉴를 닫는 중",
   "ExitingDeckBuilder": "덱 빌더를 종료하는 중",
+  "NewDeck": "새 덱",
   "DeckInfoCardCount": "카드 수",
   "DeckInfoManaCurve": "마나 커브",
   "DeckInfoTypeBreakdown": "유형",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -29,6 +29,7 @@
   "ClosingSettings": "Zamykanie ustawień",
   "ClosingPlayBlade": "Zamykanie menu gry",
   "ExitingDeckBuilder": "Wychodzenie z edytora talii",
+  "NewDeck": "Nowa talia",
   "DeckInfoCardCount": "Liczba kart",
   "DeckInfoManaCurve": "Krzywa many",
   "DeckInfoTypeBreakdown": "Typy",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -29,6 +29,7 @@
   "ClosingSettings": "Fechando configurações",
   "ClosingPlayBlade": "Fechando menu de jogo",
   "ExitingDeckBuilder": "Saindo do construtor de decks",
+  "NewDeck": "Novo baralho",
   "DeckInfoCardCount": "Quantidade de Cartas",
   "DeckInfoManaCurve": "Curva de Mana",
   "DeckInfoTypeBreakdown": "Tipos",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -29,6 +29,7 @@
   "ClosingSettings": "Закрытие настроек",
   "ClosingPlayBlade": "Закрытие меню игры",
   "ExitingDeckBuilder": "Выход из конструктора колод",
+  "NewDeck": "Новая колода",
   "DeckInfoCardCount": "Количество карт",
   "DeckInfoManaCurve": "Кривая маны",
   "DeckInfoTypeBreakdown": "Типы",

--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -29,6 +29,7 @@
   "ClosingSettings": "正在关闭设置",
   "ClosingPlayBlade": "正在关闭游戏菜单",
   "ExitingDeckBuilder": "正在退出套牌构建器",
+  "NewDeck": "新套牌",
   "DeckInfoCardCount": "卡牌数量",
   "DeckInfoManaCurve": "法术力曲线",
   "DeckInfoTypeBreakdown": "类型",

--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -29,6 +29,7 @@
   "ClosingSettings": "正在關閉設定",
   "ClosingPlayBlade": "正在關閉遊戲選單",
   "ExitingDeckBuilder": "正在退出套牌建構器",
+  "NewDeck": "新套牌",
   "DeckInfoCardCount": "卡牌數量",
   "DeckInfoManaCurve": "魔法力曲線",
   "DeckInfoTypeBreakdown": "類型",

--- a/src/Core/Models/Strings.cs
+++ b/src/Core/Models/Strings.cs
@@ -69,6 +69,7 @@ namespace AccessibleArena.Core.Models
         public static string ClosingSettings => L.Get("ClosingSettings");
         public static string ClosingPlayBlade => L.Get("ClosingPlayBlade");
         public static string ExitingDeckBuilder => L.Get("ExitingDeckBuilder");
+        public static string NewDeck => L.Get("NewDeck");
 
         // ===========================================
         // DECK BUILDER INFO

--- a/src/Core/Services/UITextExtractor.cs
+++ b/src/Core/Services/UITextExtractor.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using AccessibleArena.Core.Models;
 using static AccessibleArena.Core.Utils.ReflectionUtils;
 
 namespace AccessibleArena.Core.Services
@@ -291,7 +292,7 @@ namespace AccessibleArena.Core.Services
 
             // NewDeckButton shows "Enter deck name..." placeholder but is actually a create deck button
             if (objectName.Contains("NewDeckButton"))
-                return "New Deck";
+                return Strings.NewDeck;
 
             return null;
         }


### PR DESCRIPTION
## Summary
- Adds `NewDeck` key to all 12 locale files
- Adds `Strings.NewDeck` property to `Strings.cs`
- Updates `UITextExtractor.GetLabelOverride()` to use `Strings.NewDeck` instead of the hardcoded English string
- Adds missing `using AccessibleArena.Core.Models` to `UITextExtractor.cs`

---
Co-Authored-By: Claude Sonnet 4.6 <claude[bot]@users.noreply.github.com>