### PR TITLE
fix: announce mail label with unread count instead of count alone

### DIFF
--- a/src/Core/Models/Strings.cs
+++ b/src/Core/Models/Strings.cs
@@ -714,6 +714,7 @@ namespace AccessibleArena.Core.Models
         public static string CurrencyGold => L.Get("CurrencyGold");
         public static string CurrencyGems => L.Get("CurrencyGems");
         public static string CurrencyWildcards => L.Get("CurrencyWildcards");
+        public static string NavMail => L.Get("GroupMail");
 
         // ===========================================
         // MANA SYMBOLS (for rules text parsing)

--- a/src/Core/Services/UITextExtractor.cs
+++ b/src/Core/Services/UITextExtractor.cs
@@ -321,6 +321,18 @@ namespace AccessibleArena.Core.Services
                     : label;
             }
 
+            if (name == "Nav_Mail")
+            {
+                // NavBarMailController shows an unread count badge (TMP_Text UnreadMailCount) when
+                // there are unread messages. When active it returns just the count ("1", "2", etc.),
+                // losing the "Mail" label. Intercept here to always return "Mail: N" or "Mail".
+                var tmpText = gameObject.GetComponentInChildren<TMP_Text>();
+                string count = tmpText != null ? CleanText(tmpText.text) : "";
+                return !string.IsNullOrEmpty(count)
+                    ? LocaleManager.Instance.Format("LabelValue_Format", Models.Strings.NavMail, count)
+                    : Models.Strings.NavMail;
+            }
+
             if (name == "Nav_WildCard")
             {
                 // Read TooltipData.Text from TooltipTrigger component (same pattern as UIActivator)


### PR DESCRIPTION
## Summary

When the inbox has unread messages, `NavBarMailController` activates its `UnreadMailCount` TMP_Text child showing e.g. `"1"`. The generic `GetComponentInChildren<TMP_Text>()` fallback in `GetText` was returning just `"1"`, dropping the `"Mail"` label entirely — so the nav item was announced as `"1"` instead of `"Mail: 1"`.

Fix intercepts `Nav_Mail` in `TryGetCurrencyLabel` (same pattern as `Nav_Coins`/`Nav_Gems`) to always return the localized label, appending the count when the badge is active:

- No unread → `"Mail"`
- 1 unread → `"Mail: 1"`
- 3 unread → `"Mail: 3"`

Reuses the existing `GroupMail` locale key (already translated in all 12 languages) and `LabelValue_Format` for consistency with Gold/Gems.

---
Co-Authored-By: Claude Sonnet 4.6 <claude[bot]@users.noreply.github.com>
Human testing verification: Blindndangerous