### PR TITLE
fix: read Daily/Weekly objective descriptions and restore wins unit

### DIFF
--- a/src/Core/Services/UITextExtractor.cs
+++ b/src/Core/Services/UITextExtractor.cs
@@ -1193,12 +1193,13 @@ namespace AccessibleArena.Core.Services
                 // Build label based on objective type
                 if (objectiveType == "Daily")
                 {
-                    // Daily: "description, progress, reward gold"
+                    // If game provides a TextLine description, use it.
+                    // Otherwise fall back to the win-count format (Daily is always win-based).
                     var parts = new System.Collections.Generic.List<string>();
                     if (!string.IsNullOrEmpty(description))
                         parts.Add(description);
                     if (!string.IsNullOrEmpty(progressValue))
-                        parts.Add(progressValue);
+                        parts.Add(string.IsNullOrEmpty(description) ? progressValue + " wins" : progressValue);
                     if (!string.IsNullOrEmpty(mainValue))
                         parts.Add($"{mainValue} gold");
                     if (parts.Count > 0)
@@ -1214,12 +1215,13 @@ namespace AccessibleArena.Core.Services
                 }
                 else
                 {
-                    // Weekly, SparkRank, etc: show description, progress, main value
+                    // Weekly, SparkRank, etc: prefer description from TextLine, fall back to progress.
+                    // Weekly is also win-based, so append "wins" when no description is available.
                     var parts = new System.Collections.Generic.List<string>();
                     if (!string.IsNullOrEmpty(description))
                         parts.Add(description);
                     if (!string.IsNullOrEmpty(progressValue))
-                        parts.Add(progressValue);
+                        parts.Add(string.IsNullOrEmpty(description) && objectiveType == "Weekly" ? progressValue + " wins" : progressValue);
                     else if (!string.IsNullOrEmpty(mainValue))
                         parts.Add(mainValue);
                     if (parts.Count > 0)


### PR DESCRIPTION
## Summary

- Daily objectives now read: \`Daily: 0/15 wins, 250 gold\`
- Weekly objectives now read: \`Weekly: 0/15 wins\` (previously just \`Weekly: 0/15\` with no context of what the number meant)
- Added \`TextLine\` child reading for Daily/Weekly in \`TryGetObjectiveText\` — if the game ever adds a text description to these objective types, it will be included automatically
- \`QuestNormal\` objectives are unchanged and continue to work correctly (e.g. \`Cast 30 blue or black spells., 6/30, 750 gold\`)

## Test plan

- [x] Navigate to Home screen → Progress group → Objectives subgroup
- [x] Confirm Daily objective announces progress and gold reward with "wins" unit (e.g. \`Daily: 0/15 wins, 250 gold\`)
- [x] Confirm Weekly objective announces progress with "wins" unit (e.g. \`Weekly: 0/15 wins\`)
- [x] Confirm QuestNormal objectives still announce description, progress, and reward correctly

Closes #44

Human testing verification: blindndangerous
Co-Authored-By: Claude Sonnet 4.6 <claude[bot]@users.noreply.github.com>