### PR TITLE
fix: ChatNavigator now activates when chat is open

### DIFF
--- a/src/Core/Services/ChatNavigator.cs
+++ b/src/Core/Services/ChatNavigator.cs
@@ -153,17 +153,9 @@ namespace AccessibleArena.Core.Services
 
         private MonoBehaviour FindChatWindow(GameObject socialPanel)
         {
-            var safeArea = socialPanel.transform.Find("MobileSafeArea");
-            if (safeArea == null) return null;
-
-            foreach (Transform child in safeArea)
-            {
-                if (!child.gameObject.activeInHierarchy) continue;
-                var comp = FindComponentByTypeName(child.gameObject, T.ChatWindow);
-                if (comp != null) return comp;
-            }
-
-            return null;
+            // ChatWindow is instantiated under SocialUI._safeZoneRoot (not MobileSafeArea).
+            // Search the entire panel hierarchy for an active ChatWindow component.
+            return FindComponentByTypeName(socialPanel, T.ChatWindow);
         }
 
         private MonoBehaviour FindComponentByTypeName(GameObject go, string typeName)


### PR DESCRIPTION
## Summary

\`ChatNavigator.FindChatWindow\` was searching for the \`ChatWindow\` component under a child named \`MobileSafeArea\`, but the game instantiates it under \`SocialUI._safeZoneRoot\` which has a different name. This meant \`FindChatWindow\` always returned \`null\`, \`DetectScreen()\` always returned \`false\`, and \`ChatNavigator\` never activated when chat was open.

As a result, no navigator owned the chat UI — pressing Backspace had no effect on chat.

**Fix:** Search the entire social panel hierarchy for an active \`ChatWindow\` component instead of restricting to \`MobileSafeArea\`.

## Test plan

- [ ] Open Friends panel → open a chat with a friend
- [ ] Confirm NVDA announces the chat (friend name, message count)
- [ ] Confirm Up/Down navigates messages, input field, and send button
- [ ] Press Backspace → confirm chat closes and NVDA announces closure
- [ ] Confirm Tab switches between conversations (if multiple exist)

Closes #42

Co-Authored-By: Claude Sonnet 4.6 <claude[bot]@users.noreply.github.com>
Blindndangerous: I don't have any chats to test this with, sorry I couldn't verify this one.