### PR TITLE
fix: rescan element list after booster carousel navigation (issue #47)

### DIFF
--- a/src/Core/Services/GeneralMenuNavigator.cs
+++ b/src/Core/Services/GeneralMenuNavigator.cs
@@ -709,6 +709,12 @@ namespace AccessibleArena.Core.Services
             // Update the element label
             UpdateBoosterCarouselElement();
 
+            // Rescan after carousel switch so button states reflect the newly selected pack.
+            // The "Open x10" button updates asynchronously when the game centers the new pack,
+            // so a delayed rescan is needed to pick up the correct enabled/disabled state.
+            _suppressRescanAnnouncement = true;
+            TriggerRescan();
+
             return true;
         }
 


### PR DESCRIPTION
## Summary

- After opening packs of one type and returning to the BoosterChamber carousel, switching to a different pack type via Left/Right arrows left the element list stale
- The \"Open x10\" button state was captured at re-activation time (for the depleted Type A), not updated when the carousel moved to Type B
- Added a 0.5s delayed rescan after carousel navigation so button states reflect the newly selected pack type

## Investigation Notes (for reviewer)

**Root cause is uncertain — this is a best-guess fix that needs testing.**

Possible causes investigated:
1. `BoosterOpenNavigator` staying active too long after dismiss (60-frame close rescan timer) — could cause input to go to the wrong navigator for ~1 second after closing packs. Not addressed here.
2. `_cardsToOpen` not being cleared synchronously by the game after `Dismiss_MainButton` is clicked — could keep `BoosterOpenNavigator` alive indefinitely. Would need a log to confirm.
3. **The fix applied:** No rescan after carousel navigation → "Open x10" button held stale state from the previous (depleted) pack type.

If testing shows this doesn't fix the issue, a MelonLoader log file would be needed to trace whether `BoosterOpenNavigator` is still active when the second "Open All" is attempted.

## Test plan

- [ ] Open all packs of one type via "Open x10"
- [ ] Close the pack reveal screen (Backspace)
- [ ] Navigate carousel to a different pack type (Left/Right)
- [ ] Navigate to the "Open x10" button and press Enter
- [ ] Confirm packs open correctly for the second type

Co-Authored-By: Claude Sonnet 4.6 <claude[bot]@users.noreply.github.com>