### PR TITLE
fix: always announce when closing mailbox or mail detail view

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -213,6 +213,20 @@ After completing all 5 NPE tutorial stages, the game shows a deck reward screen 
 - Does Backspace activate the Continue button (`NullClaimButton`)?
 - Does `UITextExtractor.GetText()` extract deck names, or does it fall back to "Deck 1", "Deck 2", etc.?
 
+## Under Investigation
+
+### Mailbox Close Restores to Wrong Group
+
+After closing the mailbox with Backspace, the GroupedNavigator restores to "Decks" on the home screen instead of the group the user was in before opening the mailbox (e.g., "Social"). The user can then navigate with Up/Down to find their position.
+
+**Root cause:** When navigating inside the mailbox, the GroupedNavigator saves the current mail item position as `ElementGroup.Content`. On the home screen, the first `ElementGroup.Content`-typed group happens to be "Decks", so the restore succeeds but in the wrong place. The pre-mailbox position (Social, InsideGroup) is overwritten by the mailbox's internal navigation saves.
+
+**Fix needed:** Save the home screen GroupedNavigator state when the mailbox opens, then restore to it explicitly in `CloseMailbox()` rather than relying on the auto-restore mechanism.
+
+**Files:** `GeneralMenuNavigator.cs` (CloseMailbox, OverlayChanged handler)
+
+---
+
 ## Not Reproducible Yet
 
 ### Game Assets Loading Problem

--- a/src/Core/Services/GeneralMenuNavigator.cs
+++ b/src/Core/Services/GeneralMenuNavigator.cs
@@ -1864,7 +1864,7 @@ namespace AccessibleArena.Core.Services
                             {
                                 LogDebug($"[{NavigatorId}] Invoking NavBarController.HideInboxIfActive()");
                                 method.Invoke(mb, null);
-                                _announcer.AnnounceVerbose(Models.Strings.NavigatingBack, Models.AnnouncementPriority.High);
+                                _announcer.Announce(Models.Strings.NavigatingBack, Models.AnnouncementPriority.High);
                                 TriggerRescan();
                                 return true;
                             }
@@ -1885,7 +1885,7 @@ namespace AccessibleArena.Core.Services
                 var closeButton = FindCloseButtonInPanel(mailboxPanel);
                 if (closeButton != null)
                 {
-                    _announcer.AnnounceVerbose(Models.Strings.NavigatingBack, Models.AnnouncementPriority.High);
+                    _announcer.Announce(Models.Strings.NavigatingBack, Models.AnnouncementPriority.High);
                     UIActivator.Activate(closeButton);
                     TriggerRescan();
                     return true;
@@ -1922,7 +1922,7 @@ namespace AccessibleArena.Core.Services
                                 _isInMailDetailView = false;
                                 _currentMailLetterId = Guid.Empty;
                                 ResetMailFieldNavigation();
-                                _announcer.AnnounceVerbose(Models.Strings.BackToMailList, Models.AnnouncementPriority.High);
+                                _announcer.Announce(Models.Strings.BackToMailList, Models.AnnouncementPriority.High);
                                 TriggerRescan();
                                 return true;
                             }


### PR DESCRIPTION
## Summary

- `CloseMailbox()` and `CloseMailDetailView()` both used `AnnounceVerbose` for back-navigation feedback
- `AnnounceVerbose` is gated by the `VerboseAnnouncements` setting, which is off by default
- With verbose off, both transitions were completely silent — the user heard nothing after pressing Backspace and had to press Up/Down to discover they were back on the home screen, perceiving this as needing two Backspace presses
- Changed both to `Announce()` so the feedback fires regardless of the verbose setting

## Changes

- `CloseMailDetailView`: "Back to mail list" now always announces on first Backspace
- `CloseMailbox` (primary and fallback paths): "Navigating back" now always announces on second Backspace
- Documented a separate wrong-group-restore issue in `KNOWN_ISSUES.md` (after closing the mailbox, navigator lands on "Decks" instead of the pre-mailbox group — tracked for a future fix)

## Test plan

- [ ] Navigate to home screen, enter the Social group
- [ ] Press Enter on Mail — hear "Mailbox opened"
- [ ] Open a mail with Enter
- [ ] Press Backspace — hear "Back to mail list" immediately
- [ ] Press Backspace again — hear "Navigating back" immediately
- [ ] Press Up/Down — hear home screen group names confirming you are back

Co-Authored-By: Claude Sonnet 4.6 <claude[bot]@users.noreply.github.com>