### PR TITLE
fix: skip battlefield row shortcuts when browser overlay is active

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -112,6 +112,18 @@ Steam's default overlay hotkey (Shift+Tab) conflicts with the mod's backward nav
 
 ## Monitoring
 
+### AssignDamage Browser — Shift+B Announced "Enemy Creatures Empty"
+
+During the first `CombatDamage` phase when an `AssignDamage` browser was active, pressing Shift+B to view opponent creatures announced "Enemy creatures, empty" even though creatures existed.
+
+**Root cause:** When the user pressed B, `BattlefieldNavigator.HandleInput()` called `SetCurrentZone(ZoneType.Battlefield, ...)`, stealing zone ownership from `BrowserNavigator`. The opponent's blocking creatures were held in the browser's card list and were not visible to the battlefield scan, so `EnemyCreatures` came up empty.
+
+**Fix applied:** Added a `BrowserNavigator.IsActive` guard at the top of `BattlefieldNavigator.HandleInput()`. When any browser overlay is active, the A/B/R row-shortcut handlers return without stealing zone ownership. The browser remains in control and no incorrect "empty" announcement fires.
+
+**Files:** `BattlefieldNavigator.cs` (HandleInput)
+
+---
+
 ### NPE Tutorial Combat Cancel Lock
 
 During the first NPE tutorial fight (Game01, Turn 4), pressing Backspace to cancel attacks after the NPE prompted "attack with your creatures" caused a locked state. The NPE script doesn't handle attack cancellation at this stage — no highlights reappear, the primary button has empty text, and the game becomes unresponsive until a system message popup (timeout/disconnect) appears.

--- a/src/Core/Services/BattlefieldNavigator.cs
+++ b/src/Core/Services/BattlefieldNavigator.cs
@@ -137,6 +137,12 @@ namespace AccessibleArena.Core.Services
             // Per-frame: check if a watched card's state changed after Enter click
             CheckWatchedCardState();
 
+            // Don't process battlefield shortcuts while a browser overlay is active.
+            // Cards in the browser (e.g. AssignDamage blockers) are not on the battlefield,
+            // so A/B/R would produce incorrect "empty" announcements.
+            if (BrowserNavigator.IsActive)
+                return false;
+
             bool shift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
 
             // Row shortcuts: A for lands (also announces floating mana for player lands)


### PR DESCRIPTION
## Summary

- During `CombatDamage` phase with an `AssignDamage` browser open, pressing Shift+B (enemy creatures) stole zone ownership from `BrowserNavigator` and announced "Enemy creatures, empty" — even though the opponent's blocking creatures existed in the browser
- Root cause: `BattlefieldNavigator.HandleInput()` called `SetCurrentZone(Battlefield, ...)` unconditionally when A/B/R were pressed, with no check for an active browser overlay. The creatures were in the browser's card list, not the battlefield, so `DiscoverAndCategorizeCards()` found `EnemyCreatures` empty
- Fix: added `BrowserNavigator.IsActive` guard at the top of `HandleInput()` — when any browser is active, A/B/R return false without stealing the zone

## Test plan

- [ ] Start a duel where combat goes to `CombatDamage` phase with an `AssignDamage` browser (opponent has multiple blockers)
- [ ] While the damage assignment browser is open, press Shift+B — should not announce "Enemy creatures, empty"
- [ ] Complete damage assignment normally (Space to confirm)
- [ ] After the browser closes, Shift+B should correctly announce enemy creatures
- [ ] Verify A and R shortcuts also work correctly after browser closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <claude[bot]@users.noreply.github.com>