### PR TITLE
fix: require display name match when restoring group position after rescan

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -112,6 +112,18 @@ Steam's default overlay hotkey (Shift+Tab) conflicts with the mod's backward nav
 
 ## Monitoring
 
+### Wrong Group Restore After Closing Mailbox
+
+After closing the mailbox, the navigator landed on "Decks" instead of the pre-mailbox group (e.g., "Social"), and no screen announcement fired so the user didn't know they had returned to the home screen.
+
+**Root cause:** The group restore logic saved `ElementGroup.Content` + a mailbox display name. After closing, it rescanned the home screen, found no Content group with that display name, then fell back to the first Content group by type — which was "Decks". Setting `PositionWasRestored = true` on that fallback match suppressed the home-screen announcement.
+
+**Fix applied:** Removed the type-only fallback. Restore now requires an exact type + display name match. If no match is found, `PositionWasRestored` stays false and the screen announcement fires normally.
+
+**Files:** `GroupedNavigator.cs` (OrganizeIntoGroups restore block)
+
+---
+
 ### NPE Tutorial Combat Cancel Lock
 
 During the first NPE tutorial fight (Game01, Turn 4), pressing Backspace to cancel attacks after the NPE prompted "attack with your creatures" caused a locked state. The NPE script doesn't handle attack cancellation at this stage — no highlights reappear, the primary button has empty text, and the game becomes unresponsive until a system message popup (timeout/disconnect) appears.

--- a/src/Core/Services/ElementGrouping/GroupedNavigator.cs
+++ b/src/Core/Services/ElementGrouping/GroupedNavigator.cs
@@ -1130,20 +1130,14 @@ namespace AccessibleArena.Core.Services.ElementGrouping
                     _pendingLevelRestore = NavigationLevel.GroupList;
                     _pendingElementIndexRestore = -1;
 
-                    // Find the group to restore.
-                    // When multiple groups share the same type (e.g. folder groups and standalone Content
-                    // items both use ElementGroup.Content), prefer the one whose display name matches
-                    // the saved display name. This ensures "My Decks" folder restores correctly
-                    // instead of landing on the first Content item (e.g., "All Decks, dropdown").
+                    // Find the group to restore by exact type + display name match.
+                    // Display name must match to avoid landing on a same-typed group from a
+                    // different screen (e.g. closing the mailbox must not restore to "Decks"
+                    // just because both use ElementGroup.Content).
                     bool found = false;
-                    int fallbackIndex = -1;
                     for (int i = 0; i < _groups.Count; i++)
                     {
                         if (_groups[i].Group != groupToRestore) continue;
-
-                        if (fallbackIndex < 0) fallbackIndex = i; // first match as fallback
-
-                        // Prefer exact display name match
                         if (displayNameToRestore != null &&
                             _groups[i].DisplayName == displayNameToRestore)
                         {
@@ -1151,13 +1145,6 @@ namespace AccessibleArena.Core.Services.ElementGrouping
                             found = true;
                             break;
                         }
-                    }
-
-                    // Fall back to first type match if no display-name match found
-                    if (!found && fallbackIndex >= 0)
-                    {
-                        _currentGroupIndex = fallbackIndex;
-                        found = true;
                     }
 
                     if (found)


### PR DESCRIPTION
## Summary

- After closing the mailbox, the navigator silently landed on "Decks" instead of the pre-mailbox group (e.g. "Social") — no announcement fired so the user had no idea they were back on the home screen
- Root cause: the group restore fallback matched any same-typed group when no display-name match was found. `ElementGroup.Content` covers both mailbox items and the home screen Decks group, so closing the mailbox triggered a false restore to "Decks" and set `PositionWasRestored=true`, which suppressed the home-screen announcement
- Fix: removed the type-only fallback. Restore now requires an exact type + display name match. If no match is found, `PositionWasRestored` stays false and the screen announcement fires normally

## Test plan

- [ ] Open the mailbox from the home screen (from any group, e.g. "Social")
- [ ] Press Backspace once — should announce "Back to mail list" (mail list level)
- [ ] Press Backspace again — should announce "Navigating back" and return to home screen
- [ ] Pressing Up/Down should announce the home screen groups (not silently land on "Decks")
- [ ] Verify within-screen group restore still works: enter a deck folder (e.g. "My Decks"), trigger a stepper rescan — should restore to "My Decks", not drift to "All Decks"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <claude[bot]@users.noreply.github.com>