### PR TITLE
fix: phase-skip guard modal bypass lost after first duel

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Accessible Arena.
 
 ## v0.9
 
+### Phase-Skip Guard Fix (Browser Space Lockup in 2nd+ Duels)
+- Fixed a bug where pressing Space inside a browser (scry, surveil, SelectCards, etc.) during main phase with untapped lands would trigger the phase-skip warning instead of confirming the browser selection — this affected all duels after the first, making friend matches appear completely broken
+- Root cause: `PhaseSkipGuard.Reset()` was clearing the modal-navigator callback that tells the guard to bypass browsers. That callback is wired once at startup and must persist across duel resets.
+
 ### SelectGroup Browser Fix (untested)
 - Fixed Fact or Fiction / Curator of Destinies pile selection browser: Enter and Space now correctly activate the focused pile button instead of clicking a random card or falling through to "Opponent's Turn"
 

--- a/src/Core/Services/PhaseSkipGuard.cs
+++ b/src/Core/Services/PhaseSkipGuard.cs
@@ -146,7 +146,9 @@ namespace AccessibleArena.Core.Services
             _confirmedPhase = null;
             _blockThisFrame = false;
             _lastDecisionFrame = -1;
-            _isModalNavigatorActive = null;
+            // Do not clear _isModalNavigatorActive — it is wired once from DuelNavigator's
+            // constructor and must survive duel-end resets. Clearing it caused browsers
+            // to lose their Space bypass in every duel after the first.
         }
 
         private static bool HasUntappedPlayerLands()


### PR DESCRIPTION
## Summary

- `PhaseSkipGuard.Reset()` was clearing `_isModalNavigatorActive`, the callback that tells the guard to bypass browsers and chooseX navigators when Space is pressed
- That callback is wired once in `DuelNavigator`'s constructor and must survive duel-end resets
- In every duel after the first, browsers (scry, surveil, SelectCards, etc.) lost their Space bypass — pressing Space to confirm a browser during main phase with untapped lands triggered the phase-skip warning and blocked the key, making the browser unresolvable
- Friend matches appeared uniquely broken because they are typically the user's second match (reported by patricus3, JeanStiletto/AccessibleArena#55)
- Fix: remove the `_isModalNavigatorActive = null` line from `Reset()`

## Test plan

- [ ] Play a bot/ranked match to completion (first duel)
- [ ] Start a second duel immediately after
- [ ] During main phase with untapped lands, trigger a browser (e.g. cast a Scry spell)
- [ ] Press Space to confirm the browser — should work without phase-skip warning firing
- [ ] Also verify: pressing Space to pass turn (not inside a browser) with untapped lands still shows the warning correctly

Co-authored-by: claude[bot] <claude[bot]@users.noreply.github.com>