### PR TITLE
fix: re-read objective labels live to fix stale quest progress after a duel

### DIFF
--- a/src/Core/Services/BaseNavigator.cs
+++ b/src/Core/Services/BaseNavigator.cs
@@ -239,6 +239,15 @@ namespace AccessibleArena.Core.Services
         {
             if (obj == null) return label;
 
+            // Re-read objective text live — quest progress updates async after the home page
+            // finishes its server round-trip, so cached labels from rescan time are stale.
+            if (obj.name == "ObjectiveGraphics")
+            {
+                string freshText = UITextExtractor.GetText(obj);
+                if (!string.IsNullOrEmpty(freshText))
+                    return freshText;
+            }
+
             // Update state for toggles - replace cached checkbox state with current state
             var toggle = obj.GetComponent<Toggle>();
             if (toggle != null && (role == UIElementClassifier.ElementRole.Toggle || role == UIElementClassifier.ElementRole.Unknown))


### PR DESCRIPTION
## Summary

- Fixes dailies/weeklies not reflecting updated progress after returning from a duel (reported in #73)
- Root cause: `ShowQuestBar` does a server round-trip before rebuilding objective bubbles; the mod's rescan fires when the panel appears — before that async rebuild completes — so cached labels held pre-duel progress counts
- Fix: `RefreshElementLabel` now re-reads `ObjectiveGraphics` text live from the UI on every navigation instead of returning a stale cached label

## Test plan

- [ ] Complete a daily or weekly quest objective during a game (e.g. win a match that counts toward a quest)
- [ ] Return to the home screen and navigate to the objectives panel
- [ ] Verify the announced quest progress reflects the updated count, not the value from before the game

Co-Authored-By: claude[bot] <claude[bot]@users.noreply.github.com>