### PR TITLE
fix: clear _creatureDamage on duel end to prevent stale damage in next game

### DIFF
--- a/src/Core/Services/DuelAnnouncer.cs
+++ b/src/Core/Services/DuelAnnouncer.cs
@@ -189,6 +189,7 @@ namespace AccessibleArena.Core.Services
             _pendingPhaseAnnouncement = null;
             DuelHolderCache.Clear();
             _instanceIdToName.Clear();
+            _creatureDamage.Clear();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- `_creatureDamage` (`Dictionary<uint, uint>`) was never cleared in `Deactivate()` unlike other state dictionaries (`DuelHolderCache`, `_instanceIdToName`)
- Game instance IDs can be reused across duels; stale values caused `HandleCardModelUpdate` to read the previous duel's damage value and announce false damage in the new game
- Fix: add `_creatureDamage.Clear()` to `Deactivate()` alongside the other `.Clear()` calls

## Test plan
- [ ] Play two consecutive duels
- [ ] In the first duel, deal damage to a creature (e.g. shock a 2/2 to create a 2/1)
- [ ] In the second duel, verify damage announcements are fresh — no leftover values from the first game

## Human testing
Not yet tested by maintainer — pre-emptive fix for a reproducible edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: claude[bot] <claude[bot]@users.noreply.github.com>