### PR TITLE
fix: skip ghost resolution announcement if duel ended during coroutine delay

### DIFF
--- a/src/Core/Services/DuelAnnouncer.cs
+++ b/src/Core/Services/DuelAnnouncer.cs
@@ -2296,6 +2296,7 @@ namespace AccessibleArena.Core.Services
             yield return null;
             yield return null;
             yield return null;
+            if (!_isActive) yield break;
             AnnounceToLog(message, AnnouncementPriority.Normal);
         }
 


### PR DESCRIPTION
## Summary
- `AnnounceResolvedDelayed` waits 4 frames (`yield return null` × 4) before calling `AnnounceToLog`
- If the duel ends during those 4 frames (concede, opponent disconnect, scene change), `_isActive` becomes `false` but the coroutine completes unconditionally, firing a stale card-resolved announcement on the home screen
- Fix: add `if (!_isActive) yield break;` after the yields, before the announcement

## Test plan
- [ ] Cast a spell, then concede immediately while the stack is resolving
- [ ] Verify no resolution announcement fires after returning to the home screen

## Human testing
Not yet tested by maintainer — pre-emptive fix for a reproducible edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: claude[bot] <claude[bot]@users.noreply.github.com>