### PR TITLE
fix: stop announcing non-selectable card when no selectable cards exist in browser

### DIFF
--- a/src/Core/Services/BrowserNavigator.cs
+++ b/src/Core/Services/BrowserNavigator.cs
@@ -501,7 +501,7 @@ namespace AccessibleArena.Core.Services
                         if (_browserCards.Count > 0)
                         {
                             int firstIdx = FindFirstSelectableCard();
-                            _currentCardIndex = firstIdx >= 0 ? firstIdx : 0;
+                            _currentCardIndex = firstIdx; // -1 if none selectable; guard in AnnounceCurrentCard handles it
                             _currentButtonIndex = -1;
                             AnnounceCurrentCard();
                         }
@@ -524,7 +524,7 @@ namespace AccessibleArena.Core.Services
                         else if (_browserCards.Count > 0)
                         {
                             int lastIdx = FindLastSelectableCard();
-                            _currentCardIndex = lastIdx >= 0 ? lastIdx : _browserCards.Count - 1;
+                            _currentCardIndex = lastIdx; // -1 if none selectable; guard in AnnounceCurrentCard handles it
                             AnnounceCurrentCard();
                         }
                     }
@@ -1425,7 +1425,7 @@ namespace AccessibleArena.Core.Services
             {
                 // Start on first selectable card (skips non-selectable in filtered browsers)
                 int firstIdx = FindFirstSelectableCard();
-                _currentCardIndex = firstIdx >= 0 ? firstIdx : 0;
+                _currentCardIndex = firstIdx; // -1 if none selectable; guard in AnnounceCurrentCard handles it
                 AnnounceCurrentCard();
             }
             else if (buttonCount > 0)


### PR DESCRIPTION
## Summary
- `FindFirstSelectableCard()` and `FindLastSelectableCard()` correctly return `-1` when no selectable card exists (e.g. all cards are filtered out in a Scry/Surveil browser)
- Three call sites used a ternary that discarded the `-1` and fell back to index `0` or `Count-1`, causing `AnnounceCurrentCard` to announce the wrong card even though a guard inside that method prevents a crash
- Fix: pass `-1` through unchanged at all three call sites (lines 503–506, 526–528, 1427–1429); the existing guard in `AnnounceCurrentCard` handles `-1` cleanly

## Test plan
- [ ] Enter a Scry or Surveil browser where all cards visible in one zone are non-selectable
- [ ] Verify no card name is announced — or a correct "no selectable cards" message — rather than a random card name

## Human testing
Not yet tested by maintainer — pre-emptive fix for a reproducible edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: claude[bot] <claude[bot]@users.noreply.github.com>