### PR TITLE
feat(card-info): read chosen type / named card on the card readout

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Accessible Arena.
 
+## v1.3
+
+Duel:
+
+- Card info readout now surfaces chosen / named-card data. Cards that record a creature type (Cavern of Souls, Engineered Plague), a color (Iona, Shield of Emeria), or a card name (Pithing Needle, Meddling Mage, Cabal Therapy) display that pick in their on-card rules text for sighted players; the mod was dropping it. Arrow Down past rules text now reads "Chosen: Wizard" and "Named card: Cabal Therapy" sourced from `MtgCardInstance.LinkedInfoText` and `LinkedInfoTitleLocIds` via the same `IGreLocProvider` path the game's own `LinkedInfoTextParser` / `LinkedInfoTitleTextParser` use, so the resolved strings match what's rendered on the card face.
+
 ## v1.2
 
 Duel:

--- a/docs/CONTRIBUTING_TRANSLATIONS.md
+++ b/docs/CONTRIBUTING_TRANSLATIONS.md
@@ -233,6 +233,8 @@ Below is every key in `en.json` with context about where it appears and what the
 | `CardInfoPowerToughness` | "Power and Toughness" | Creature P/T |
 | `CardInfoType` | "Type" | Card type line |
 | `CardInfoRules` | "Rules" | Rules text |
+| `CardInfoChosen` | "Chosen" | Block label for the chosen type/color recorded on a card by effects like Cavern of Souls (LinkedInfoText). Read after rules text. |
+| `CardInfoNamedCard` | "Named card" | Block label for card names recorded on a card by Pithing Needle / Meddling Mage / Cabal Therapy (LinkedInfoTitleLocIds). Read after rules text. |
 | `CardInfoFlavor` | "Flavor" | Flavor text |
 | `CardInfoArtist` | "Artist" | Card artist |
 | `CardPosition_Format` | "{0}{1}, {2} of {3}" | {0} = card name, {1} = status suffix, {2} = position, {3} = total |

--- a/lang/de.json
+++ b/lang/de.json
@@ -126,6 +126,8 @@
   "CardInfoPowerToughness": "Stärke und Widerstandskraft",
   "CardInfoType": "Typ",
   "CardInfoRules": "Regeln",
+  "CardInfoChosen": "Gewählt",
+  "CardInfoNamedCard": "Genannte Karte",
   "LoyaltyPlus": "Plus",
   "LoyaltyMinus": "Minus",
   "CardInfoFlavor": "Hintergrundtext",

--- a/lang/en.json
+++ b/lang/en.json
@@ -126,6 +126,8 @@
   "CardInfoPowerToughness": "Power and Toughness",
   "CardInfoType": "Type",
   "CardInfoRules": "Rules",
+  "CardInfoChosen": "Chosen",
+  "CardInfoNamedCard": "Named card",
   "LoyaltyPlus": "Plus",
   "LoyaltyMinus": "Minus",
   "CardInfoFlavor": "Flavor",

--- a/lang/es.json
+++ b/lang/es.json
@@ -126,6 +126,8 @@
   "CardInfoPowerToughness": "Fuerza y resistencia",
   "CardInfoType": "Tipo",
   "CardInfoRules": "Reglas",
+  "CardInfoChosen": "Elegido",
+  "CardInfoNamedCard": "Carta nombrada",
   "LoyaltyPlus": "Más",
   "LoyaltyMinus": "Menos",
   "CardInfoFlavor": "Texto de ambientación",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -126,6 +126,8 @@
   "CardInfoPowerToughness": "Force et endurance",
   "CardInfoType": "Type",
   "CardInfoRules": "Règles",
+  "CardInfoChosen": "Choisi",
+  "CardInfoNamedCard": "Carte nommée",
   "LoyaltyPlus": "Plus",
   "LoyaltyMinus": "Moins",
   "CardInfoFlavor": "Texte d'ambiance",

--- a/lang/it.json
+++ b/lang/it.json
@@ -126,6 +126,8 @@
   "CardInfoPowerToughness": "Forza e costituzione",
   "CardInfoType": "Tipo",
   "CardInfoRules": "Regole",
+  "CardInfoChosen": "Scelto",
+  "CardInfoNamedCard": "Carta nominata",
   "LoyaltyPlus": "Più",
   "LoyaltyMinus": "Meno",
   "CardInfoFlavor": "Testo di colore",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -126,6 +126,8 @@
   "CardInfoPowerToughness": "パワーとタフネス",
   "CardInfoType": "タイプ",
   "CardInfoRules": "ルール",
+  "CardInfoChosen": "選ばれた",
+  "CardInfoNamedCard": "指定したカード",
   "LoyaltyPlus": "プラス",
   "LoyaltyMinus": "マイナス",
   "CardInfoFlavor": "フレーバー",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -126,6 +126,8 @@
   "CardInfoPowerToughness": "공격력과 방어력",
   "CardInfoType": "유형",
   "CardInfoRules": "규칙",
+  "CardInfoChosen": "선택됨",
+  "CardInfoNamedCard": "지정한 카드",
   "LoyaltyPlus": "플러스",
   "LoyaltyMinus": "마이너스",
   "CardInfoFlavor": "배경",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -126,6 +126,8 @@
   "CardInfoPowerToughness": "Siła i wytrzymałość",
   "CardInfoType": "Typ",
   "CardInfoRules": "Zasady",
+  "CardInfoChosen": "Wybrane",
+  "CardInfoNamedCard": "Nazwana karta",
   "LoyaltyPlus": "Plus",
   "LoyaltyMinus": "Minus",
   "CardInfoFlavor": "Tekst fabularny",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -126,6 +126,8 @@
   "CardInfoPowerToughness": "Poder e Resistência",
   "CardInfoType": "Tipo",
   "CardInfoRules": "Regras",
+  "CardInfoChosen": "Escolhido",
+  "CardInfoNamedCard": "Carta nomeada",
   "LoyaltyPlus": "Mais",
   "LoyaltyMinus": "Menos",
   "CardInfoFlavor": "Texto de Ambientização",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -126,6 +126,8 @@
   "CardInfoPowerToughness": "Сила и выносливость",
   "CardInfoType": "Тип",
   "CardInfoRules": "Правила",
+  "CardInfoChosen": "Выбрано",
+  "CardInfoNamedCard": "Названная карта",
   "LoyaltyPlus": "Плюс",
   "LoyaltyMinus": "Минус",
   "CardInfoFlavor": "Художественный текст",

--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -126,6 +126,8 @@
   "CardInfoPowerToughness": "力量和防御",
   "CardInfoType": "类型",
   "CardInfoRules": "规则",
+  "CardInfoChosen": "已选择",
+  "CardInfoNamedCard": "指定的牌",
   "LoyaltyPlus": "加",
   "LoyaltyMinus": "减",
   "CardInfoFlavor": "背景描述",

--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -126,6 +126,8 @@
   "CardInfoPowerToughness": "力量與防禦",
   "CardInfoType": "類型",
   "CardInfoRules": "規則",
+  "CardInfoChosen": "已選擇",
+  "CardInfoNamedCard": "指定的牌",
   "LoyaltyPlus": "加",
   "LoyaltyMinus": "減",
   "CardInfoFlavor": "背景描述",

--- a/src/Core/Models/Strings.cs
+++ b/src/Core/Models/Strings.cs
@@ -605,6 +605,8 @@ namespace AccessibleArena.Core.Models
         public static string CardInfoPowerToughness => L.Get("CardInfoPowerToughness");
         public static string CardInfoType => L.Get("CardInfoType");
         public static string CardInfoRules => L.Get("CardInfoRules");
+        public static string CardInfoChosen => L.Get("CardInfoChosen");
+        public static string CardInfoNamedCard => L.Get("CardInfoNamedCard");
         public static string LoyaltyPlus => L.Get("LoyaltyPlus");
         public static string LoyaltyMinus => L.Get("LoyaltyMinus");
         public static string CardInfoFlavor => L.Get("CardInfoFlavor");

--- a/src/Core/Services/CardDetector.cs
+++ b/src/Core/Services/CardDetector.cs
@@ -505,6 +505,7 @@ namespace AccessibleArena.Core.Services
             {
                 if (!string.IsNullOrEmpty(info.RulesText))
                     blocks.Add(new CardInfoBlock(Models.Strings.CardInfoRules, info.RulesText));
+                AddChosenInfoBlocks(blocks, info);
                 if (!string.IsNullOrEmpty(info.ManaCost))
                     blocks.Add(new CardInfoBlock(Models.Strings.CardInfoManaCost, info.ManaCost));
                 if (!string.IsNullOrEmpty(info.PowerToughness))
@@ -522,6 +523,7 @@ namespace AccessibleArena.Core.Services
                     blocks.Add(new CardInfoBlock(Models.Strings.CardInfoType, info.TypeLine));
                 if (!string.IsNullOrEmpty(info.RulesText))
                     blocks.Add(new CardInfoBlock(Models.Strings.CardInfoRules, info.RulesText));
+                AddChosenInfoBlocks(blocks, info);
                 // Battlefield: mana cost after rules
                 if (isBattlefield && !string.IsNullOrEmpty(info.ManaCost))
                     blocks.Add(new CardInfoBlock(Models.Strings.CardInfoManaCost, info.ManaCost));
@@ -565,6 +567,7 @@ namespace AccessibleArena.Core.Services
                 blocks.Add(new CardInfoBlock(Models.Strings.CardInfoType, info.TypeLine));
             if (!string.IsNullOrEmpty(info.RulesText))
                 blocks.Add(new CardInfoBlock(Models.Strings.CardInfoRules, info.RulesText));
+            AddChosenInfoBlocks(blocks, info);
             if (!string.IsNullOrEmpty(info.FlavorText))
                 blocks.Add(new CardInfoBlock(Models.Strings.CardInfoFlavor, info.FlavorText));
             if (!string.IsNullOrEmpty(info.Rarity))
@@ -573,6 +576,18 @@ namespace AccessibleArena.Core.Services
             AddSetAndArtistBlock(blocks, info);
 
             return blocks;
+        }
+
+        /// <summary>
+        /// Adds chosen-type and named-card blocks right after rules text — same position as the
+        /// game's own LinkedInfoTextParser, which folds those lines into rules text.
+        /// </summary>
+        private static void AddChosenInfoBlocks(List<CardInfoBlock> blocks, CardInfo info)
+        {
+            if (!string.IsNullOrEmpty(info.ChosenInfo))
+                blocks.Add(new CardInfoBlock(Models.Strings.CardInfoChosen, info.ChosenInfo));
+            if (!string.IsNullOrEmpty(info.NamedCards))
+                blocks.Add(new CardInfoBlock(Models.Strings.CardInfoNamedCard, info.NamedCards));
         }
 
         private static void AddSetAndArtistBlock(List<CardInfoBlock> blocks, CardInfo info)
@@ -730,6 +745,18 @@ namespace AccessibleArena.Core.Services
         /// Null or empty for single-ability cards.
         /// </summary>
         public List<string> RulesLines;
+        /// <summary>
+        /// Localized display string for any chosen type/color/etc. on the card (e.g. "Wizard"
+        /// for Cavern of Souls, "Blue" for Iona, "Wizard, Beast" if two are chosen).
+        /// Sourced from MtgCardInstance.LinkedInfoText. Empty/null when nothing is chosen.
+        /// </summary>
+        public string ChosenInfo;
+        /// <summary>
+        /// Localized comma-joined card names recorded on this card (e.g. "Cabal Therapy" for
+        /// Pithing Needle). Sourced from MtgCardInstance.LinkedInfoTitleLocIds. Empty/null
+        /// when no card has been named.
+        /// </summary>
+        public string NamedCards;
         public string FlavorText;
         public string Rarity;
         public string SetName;

--- a/src/Core/Services/CardModelProvider.cs
+++ b/src/Core/Services/CardModelProvider.cs
@@ -1724,6 +1724,12 @@ namespace AccessibleArena.Core.Services
                         info.RulesText = ManaTextFormatter.ParseManaSymbolsInText(overrideText);
                 }
 
+                // Chosen / named-card info - mirrors the LinkedInfoTextParser path the game uses
+                // to bake "chosen type" and "named card" lines into rules text on the battlefield.
+                var (chosenInfo, namedCards) = ChosenInfoProvider.ExtractChosenInfo(dataObj);
+                if (!string.IsNullOrEmpty(chosenInfo)) info.ChosenInfo = chosenInfo;
+                if (!string.IsNullOrEmpty(namedCards)) info.NamedCards = namedCards;
+
                 // Flavor Text - lookup via FlavorTextId
                 var flavorIdValue = GetModelPropertyValue(dataObj, objType, "FlavorTextId");
                 if (flavorIdValue != null)

--- a/src/Core/Services/CardTextProvider.cs
+++ b/src/Core/Services/CardTextProvider.cs
@@ -28,6 +28,11 @@ namespace AccessibleArena.Core.Services
         private static MethodInfo _getFlavorTextMethod = null;
         private static bool _flavorTextProviderSearched = false;
 
+        // Cache for IGreLocProvider.GetLocalizedTextForEnumValue(string, int, bool, string) —
+        // resolved off the same GreLocProvider instance as _flavorTextProvider.
+        private static MethodInfo _getEnumValueMethod = null;
+        private static bool _getEnumValueMethodSearched = false;
+
         // Cache for artist provider
         private static object _artistProvider = null;
         private static MethodInfo _getArtistMethod = null;
@@ -48,6 +53,8 @@ namespace AccessibleArena.Core.Services
             _flavorTextProvider = null;
             _getFlavorTextMethod = null;
             _flavorTextProviderSearched = false;
+            _getEnumValueMethod = null;
+            _getEnumValueMethodSearched = false;
             _artistProvider = null;
             _getArtistMethod = null;
             _artistProviderSearched = false;
@@ -416,6 +423,76 @@ namespace AccessibleArena.Core.Services
             {
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Looks up the localized name for an enum value via GreLocProvider, matching the
+        /// path the game uses inside LinkedInfoTextParser (e.g. enumName="SubType", value=42 →
+        /// "Wizard"). Reuses the same provider instance as GetLocalizedTextById; the only
+        /// extra reflection is locating the (string, int, bool, string) overload.
+        /// </summary>
+        internal static string GetLocalizedTextForEnumValue(string enumName, int value)
+        {
+            if (string.IsNullOrEmpty(enumName)) return null;
+
+            if (!_flavorTextProviderSearched)
+            {
+                _flavorTextProviderSearched = true;
+                FindFlavorTextProvider();
+            }
+            if (_flavorTextProvider == null) return null;
+
+            if (!_getEnumValueMethodSearched)
+            {
+                _getEnumValueMethodSearched = true;
+                _getEnumValueMethod = FindEnumValueMethod(_flavorTextProvider.GetType());
+                if (_getEnumValueMethod != null)
+                    Log.Card("CardTextProvider", $"Using {_flavorTextProvider.GetType().Name}.{_getEnumValueMethod.Name} for enum-value lookup");
+            }
+            if (_getEnumValueMethod == null) return null;
+
+            try
+            {
+                var ps = _getEnumValueMethod.GetParameters();
+                object[] args;
+                if (ps.Length == 4)
+                    args = new object[] { enumName, value, /*formatted*/ true, /*overrideLang*/ null };
+                else if (ps.Length == 3)
+                    args = new object[] { enumName, value, true };
+                else if (ps.Length == 2)
+                    args = new object[] { enumName, value };
+                else
+                    return null;
+
+                var text = _getEnumValueMethod.Invoke(_flavorTextProvider, args) as string;
+                if (string.IsNullOrEmpty(text) || text.StartsWith("$"))
+                    return null;
+                return text;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Finds <c>string GetLocalizedTextForEnumValue(string, int, ...)</c> on the provider —
+        /// the non-generic overload from <c>IGreLocProvider</c>. Skips the generic overload
+        /// (which constrains on <c>T : Enum</c> and isn't what we want here).
+        /// </summary>
+        private static MethodInfo FindEnumValueMethod(Type providerType)
+        {
+            foreach (var m in providerType.GetMethods(PublicInstance))
+            {
+                if (m.DeclaringType == typeof(object)) continue;
+                if (m.IsGenericMethod || m.IsGenericMethodDefinition) continue;
+                if (m.ReturnType != typeof(string)) continue;
+                if (!m.Name.Equals("GetLocalizedTextForEnumValue", StringComparison.Ordinal)) continue;
+                var ps = m.GetParameters();
+                if (ps.Length >= 2 && ps[0].ParameterType == typeof(string) && ps[1].ParameterType == typeof(int))
+                    return m;
+            }
+            return null;
         }
 
         /// <summary>

--- a/src/Core/Services/ChosenInfoProvider.cs
+++ b/src/Core/Services/ChosenInfoProvider.cs
@@ -1,0 +1,157 @@
+using UnityEngine;
+using AccessibleArena.Core.Utils;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using static AccessibleArena.Core.Utils.ReflectionUtils;
+
+namespace AccessibleArena.Core.Services
+{
+    /// <summary>
+    /// Extracts the "chosen" data carried on a card model — the creature type/color/etc. picked
+    /// for Cavern of Souls and similar, and the card names recorded by Pithing Needle / Meddling
+    /// Mage / Cabal Therapy. The game stores both on MtgCardInstance:
+    ///   <c>LinkedInfoText</c>          — list of (EnumName, Value) entries (SubType/Color/CardType/SuperType)
+    ///   <c>LinkedInfoTitleLocIds</c>   — set of card-title loc IDs (named cards)
+    /// MTGA's own rules-text pipeline reads these via Wotc.Mtga.Cards.Text.LinkedInfoTextParser
+    /// and LinkedInfoTitleTextParser; we mirror that flow so screen-reader users hear what
+    /// sighted players see baked into the card's rules text on the battlefield.
+    /// </summary>
+    public static class ChosenInfoProvider
+    {
+        private static FieldInfo _linkedInfoTextField;
+        private static bool _linkedInfoTextSearched;
+        private static FieldInfo _linkedInfoTitleLocIdsField;
+        private static bool _linkedInfoTitleLocIdsSearched;
+
+        // LinkedInfoText struct shape: (TypeCategory Category, string EnumName, int Value, LinkInfoData LinkInfo, bool Highlighted)
+        private static FieldInfo _entryEnumNameField;
+        private static FieldInfo _entryValueField;
+        private static Type _cachedEntryType;
+
+        public static void ClearCache()
+        {
+            _linkedInfoTextField = null;
+            _linkedInfoTextSearched = false;
+            _linkedInfoTitleLocIdsField = null;
+            _linkedInfoTitleLocIdsSearched = false;
+            _entryEnumNameField = null;
+            _entryValueField = null;
+            _cachedEntryType = null;
+        }
+
+        /// <summary>
+        /// Pulls the chosen-info display strings off the model. Returns a 2-tuple:
+        ///   <c>chosenTypes</c>  — comma-joined display strings for LinkedInfoText entries
+        ///                          (e.g. "Wizard" for Cavern of Souls, "Blue" for Iona).
+        ///   <c>namedCards</c>   — comma-joined card names from LinkedInfoTitleLocIds
+        ///                          (e.g. "Cabal Therapy" for Pithing Needle).
+        /// Either side may be null/empty if the card has no chosen info.
+        /// </summary>
+        public static (string chosenTypes, string namedCards) ExtractChosenInfo(object model)
+        {
+            if (model == null) return (null, null);
+            var instance = CardModelProvider.GetModelInstance(model);
+            if (instance == null) return (null, null);
+
+            string types = ExtractLinkedInfoText(instance);
+            string names = ExtractLinkedInfoTitles(instance);
+            return (types, names);
+        }
+
+        private static string ExtractLinkedInfoText(object instance)
+        {
+            try
+            {
+                if (!_linkedInfoTextSearched)
+                {
+                    _linkedInfoTextSearched = true;
+                    _linkedInfoTextField = instance.GetType().GetField("LinkedInfoText", AllInstanceFlags);
+                }
+                if (_linkedInfoTextField == null) return null;
+
+                var list = _linkedInfoTextField.GetValue(instance) as IEnumerable;
+                if (list == null) return null;
+
+                List<string> parts = null;
+                foreach (var entry in list)
+                {
+                    if (entry == null) continue;
+                    if (!TryReadEntry(entry, out string enumName, out int value)) continue;
+                    if (string.IsNullOrEmpty(enumName)) continue;
+
+                    string display = CardTextProvider.GetLocalizedTextForEnumValue(enumName, value);
+                    if (string.IsNullOrEmpty(display)) continue;
+
+                    if (parts == null) parts = new List<string>();
+                    parts.Add(display);
+                }
+                return parts == null ? null : string.Join(", ", parts);
+            }
+            catch (Exception ex)
+            {
+                Log.Warn("ChosenInfoProvider", $"LinkedInfoText read failed: {ex.Message}");
+                return null;
+            }
+        }
+
+        private static string ExtractLinkedInfoTitles(object instance)
+        {
+            try
+            {
+                if (!_linkedInfoTitleLocIdsSearched)
+                {
+                    _linkedInfoTitleLocIdsSearched = true;
+                    _linkedInfoTitleLocIdsField = instance.GetType().GetField("LinkedInfoTitleLocIds", AllInstanceFlags);
+                }
+                if (_linkedInfoTitleLocIdsField == null) return null;
+
+                var set = _linkedInfoTitleLocIdsField.GetValue(instance) as IEnumerable;
+                if (set == null) return null;
+
+                List<string> parts = null;
+                foreach (var item in set)
+                {
+                    uint locId;
+                    if (item is uint u) locId = u;
+                    else if (item is int i && i > 0) locId = (uint)i;
+                    else continue;
+                    if (locId == 0) continue;
+
+                    string name = CardTextProvider.GetLocalizedTextById(locId);
+                    if (string.IsNullOrEmpty(name)) continue;
+
+                    if (parts == null) parts = new List<string>();
+                    parts.Add(name);
+                }
+                return parts == null ? null : string.Join(", ", parts);
+            }
+            catch (Exception ex)
+            {
+                Log.Warn("ChosenInfoProvider", $"LinkedInfoTitleLocIds read failed: {ex.Message}");
+                return null;
+            }
+        }
+
+        private static bool TryReadEntry(object entry, out string enumName, out int value)
+        {
+            enumName = null;
+            value = 0;
+            var entryType = entry.GetType();
+            if (entryType != _cachedEntryType)
+            {
+                _cachedEntryType = entryType;
+                _entryEnumNameField = entryType.GetField("EnumName", AllInstanceFlags);
+                _entryValueField = entryType.GetField("Value", AllInstanceFlags);
+            }
+            if (_entryEnumNameField == null || _entryValueField == null) return false;
+            enumName = _entryEnumNameField.GetValue(entry) as string;
+            var raw = _entryValueField.GetValue(entry);
+            if (raw is int iVal) value = iVal;
+            else if (raw is uint uVal) value = (int)uVal;
+            else return false;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Cards that record a creature type (Cavern of Souls, Engineered Plague), a color (Iona), or a card name (Pithing Needle, Meddling Mage, Cabal Therapy) bake that pick into their on-card rules text for sighted players; the mod was dropping it entirely. Arrow Down past rules text now reads `Chosen: Wizard` and `Named card: Cabal Therapy`.
- The data lives on `MtgCardInstance`: `LinkedInfoText` (list of `(EnumName, Value)` entries — SubType/Color/CardType/SuperType picked on the card) and `LinkedInfoTitleLocIds` (set of card-title loc IDs for "name a card" effects). Both are exposed on `CardData` but read off the `Instance` sub-object directly via reflection.
- Display strings are resolved through the same `IGreLocProvider` path the game uses inside `Wotc.Mtga.Cards.Text.LinkedInfoTextParser` / `LinkedInfoTitleTextParser`: `GetLocalizedTextForEnumValue(enumName, value)` for the enum entries, `GetLocalizedText(locId)` for named cards. The mod already grabs a `GreLocProvider` instance off `CardDatabase` for flavor text — we reuse that same instance and just find the additional method overload.

## Changes

- New `ChosenInfoProvider` reads `LinkedInfoText` + `LinkedInfoTitleLocIds` via cached reflection on the model's `Instance` and returns two comma-joined strings.
- New `CardTextProvider.GetLocalizedTextForEnumValue(string enumName, int value)` — finds the non-generic `IGreLocProvider.GetLocalizedTextForEnumValue(string, int, bool, string)` overload on the same provider used by `GetLocalizedTextById`, caches the `MethodInfo`.
- Two new `CardInfo` fields (`ChosenInfo`, `NamedCards`) populated in `CardModelProvider.ExtractCardInfoFromObject` right after rules text.
- `CardDetector.AddChosenInfoBlocks` inserts the new blocks after rules text in all three block-building paths (Browser zone, non-Browser zone, `BuildInfoBlocks`).
- Two new locale keys (`CardInfoChosen`, `CardInfoNamedCard`) translated for all 12 languages; documented in `docs/CONTRIBUTING_TRANSLATIONS.md`.
- New `## v1.3` section in `docs/CHANGELOG.md` since v1.2 is already released.

## What's intentionally not covered

The parser has an `AssetLookupTree<LinkedInfoTextOverride>` fallback path for cards that need a custom format string (compound chosen entries). The mod doesn't replicate that — for cards that need the override, the enum-value lookup is the documented fallback inside the parser itself and should still produce a readable label.

## Test plan

- [x] `dotnet build src/AccessibleArena.csproj` — clean, 0 warnings.
- [x] `dotnet test tests/AccessibleArena.Tests` — 150/150 pass, including `StringsLocaleAlignmentTests` (verifies the two new keys exist in all 12 locales).
- [x] In-game: Cavern of Souls with a chosen creature type — Arrow Down past rules text reads `Chosen: <type>` correctly.
- [ ] Pithing Needle / Meddling Mage / Cabal Therapy (LinkedInfoTitleLocIds path) — untested for lack of decks containing them; uses the same `GetLocalizedTextById` call the mod already exercises for flavor text, so the path is well-trodden.
- [ ] Iona, Shield of Emeria (chosen color) — untested; same enum-lookup path as Cavern.

If the named-card path turns out broken in practice, the symptom would be a missing "Named card: …" block (silent no-op, never a crash) and a `LinkedInfoTitleLocIds read failed` line in `Latest.log`.