### PR TITLE
fix(surveil): read library / graveyard groups from the browser, not holders

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Accessible Arena.
 
+## v1.3
+
+Bug fixes:
+
+- Surveil zone tracking was broken: the mod's `_bottomCards` list was always empty, so every card read as "keep" regardless of where the player had moved it, Tab announcements lied about the selection, and Tab → Enter on a "milled" card retried the same direction instead of toggling it back to the library (no way to deselect short of cancelling the whole browser). Root cause: `RefreshSurveilCardLists` walked `BrowserCardHolder_ViewDismiss` for the bottom zone, a holder Surveil doesn't have — Surveil keeps both zones in a single `cardHolder` with `libraryGroup` / `graveyardGroup` lists tracking the split. The refresh now reads those lists directly via the public `GetLibraryCards()` / `GetGraveyardCards()` getters on `SurveilBrowser`, matching what the game itself queries when laying out the cards. As a belt-and-braces fix the tracked lists are also updated eagerly the moment an Enter-driven move succeeds, so `DetectCardZone` is correct during the 0.2 s window before the reconciling refresh coroutine fires (this also closes the equivalent gap for Scry, where the lists were correct after the delay but stale within it).
+
 ## v1.2
 
 Duel:

--- a/src/Core/Services/BrowserZoneNavigator.cs
+++ b/src/Core/Services/BrowserZoneNavigator.cs
@@ -397,12 +397,39 @@ namespace AccessibleArena.Core.Services
 
             if (success)
             {
+                // Eagerly reflect the move in our tracked lists so DetectCardZone is correct
+                // before the 0.2s RefreshZoneAfterDelay coroutine runs. Without this, an
+                // immediate Tab → Enter (or D → navigate → Enter) reads the stale "keep"
+                // state and retries the same direction instead of toggling back.
+                MoveCardBetweenZonesEagerly(card, _currentZone);
+
                 // Refresh after delay
                 MelonCoroutines.Start(RefreshZoneAfterDelay(cardName));
             }
             else
             {
                 _announcer.Announce(Strings.CouldNotMove(cardName), AnnouncementPriority.High);
+            }
+        }
+
+        /// <summary>
+        /// Reflects a successful single-card move between <see cref="_topCards"/> and
+        /// <see cref="_bottomCards"/> immediately, so zone-detection queries between the
+        /// activation and the delayed <see cref="RefreshCardLists"/> coroutine see the
+        /// correct state.
+        /// </summary>
+        private void MoveCardBetweenZonesEagerly(GameObject card, BrowserZoneType fromZone)
+        {
+            if (card == null) return;
+            if (fromZone == BrowserZoneType.Top)
+            {
+                _topCards.Remove(card);
+                if (!_bottomCards.Contains(card)) _bottomCards.Add(card);
+            }
+            else if (fromZone == BrowserZoneType.Bottom)
+            {
+                _bottomCards.Remove(card);
+                if (!_topCards.Contains(card)) _topCards.Add(card);
             }
         }
 
@@ -495,52 +522,64 @@ namespace AccessibleArena.Core.Services
         }
 
         /// <summary>
-        /// Refreshes card lists for Surveil browsers from two separate holders.
+        /// Refreshes card lists for Surveil browsers by reading the browser's internal
+        /// <c>libraryGroup</c> / <c>graveyardGroup</c> lists directly. Both zones live in
+        /// the same physical <c>cardHolder</c> for Surveil — the prior implementation
+        /// walked <c>BrowserCardHolder_ViewDismiss</c> for the bottom zone, which doesn't
+        /// exist on this browser, so <c>_bottomCards</c> was always empty regardless of
+        /// the player's selections.
         /// </summary>
         private void RefreshSurveilCardLists()
         {
             _topCards.Clear();
             _bottomCards.Clear();
 
-            // Find cards in BrowserCardHolder_Default (top/keep)
-            var defaultHolder = BrowserDetector.FindActiveGameObject(BrowserDetector.HolderDefault);
-            if (defaultHolder != null)
+            var browser = GetBrowserController();
+            if (browser == null)
             {
-                foreach (Transform child in defaultHolder.GetComponentsInChildren<Transform>(true))
-                {
-                    if (!child.gameObject.activeInHierarchy) continue;
-                    if (!CardDetector.IsCard(child.gameObject)) continue;
-
-                    string cardName = CardDetector.GetCardName(child.gameObject);
-                    if (BrowserDetector.IsValidCardName(cardName) && !BrowserDetector.IsDuplicateCard(child.gameObject, _topCards))
-                    {
-                        _topCards.Add(child.gameObject);
-                    }
-                }
+                Log.Warn("BrowserZoneNavigator", "Browser controller not found for Surveil refresh");
+                return;
             }
 
-            // Find cards in BrowserCardHolder_ViewDismiss (bottom)
-            var dismissHolder = BrowserDetector.FindActiveGameObject(BrowserDetector.HolderViewDismiss);
-            if (dismissHolder != null)
-            {
-                foreach (Transform child in dismissHolder.GetComponentsInChildren<Transform>(true))
-                {
-                    if (!child.gameObject.activeInHierarchy) continue;
-                    if (!CardDetector.IsCard(child.gameObject)) continue;
-
-                    string cardName = CardDetector.GetCardName(child.gameObject);
-                    if (BrowserDetector.IsValidCardName(cardName) && !BrowserDetector.IsDuplicateCard(child.gameObject, _bottomCards))
-                    {
-                        _bottomCards.Add(child.gameObject);
-                    }
-                }
-            }
-
-            // Sort by horizontal position (left to right)
-            _topCards.Sort((a, b) => a.transform.position.x.CompareTo(b.transform.position.x));
-            _bottomCards.Sort((a, b) => a.transform.position.x.CompareTo(b.transform.position.x));
+            var browserType = browser.GetType();
+            // Top = library group (cards staying on top of library)
+            FillFromCdcList(browser, browserType.GetMethod("GetLibraryCards", PublicInstance), _topCards);
+            // Bottom = graveyard group (cards being milled)
+            FillFromCdcList(browser, browserType.GetMethod("GetGraveyardCards", PublicInstance), _bottomCards);
 
             Log.Msg("BrowserZoneNavigator", $"Refreshed Surveil lists - Top: {_topCards.Count}, Bottom: {_bottomCards.Count}");
+        }
+
+        /// <summary>
+        /// Invokes a no-arg method that returns <c>List&lt;DuelScene_CDC&gt;</c> (or similar
+        /// CDC list) on the browser and copies the resulting GameObjects into <paramref name="target"/>,
+        /// filtering out the library placeholder (a CDC with no InstanceId / no real card data).
+        /// </summary>
+        private static void FillFromCdcList(object browser, MethodInfo getter, List<GameObject> target)
+        {
+            if (getter == null) return;
+            var list = getter.Invoke(browser, null) as System.Collections.IList;
+            if (list == null) return;
+            foreach (var item in list)
+            {
+                if (!(item is Component comp) || comp == null) continue;
+                var go = comp.gameObject;
+                if (go == null) continue;
+
+                // Filter out the library placeholder card SurveilBrowser inserts into libraryGroup.
+                // It has InstanceId == 0 (and no real card content), matching the Scry placeholder
+                // detection — Surveil reuses the same placeholder mechanism for its bottom card.
+                var instanceIdProp = comp.GetType().GetProperty("InstanceId", PublicInstance);
+                if (instanceIdProp != null)
+                {
+                    var id = instanceIdProp.GetValue(comp);
+                    if ((id is uint uid && uid == 0) || (id is int iid && iid == 0))
+                        continue;
+                }
+
+                if (!go.activeInHierarchy) continue;
+                if (!target.Contains(go)) target.Add(go);
+            }
         }
 
         /// <summary>
@@ -1368,6 +1407,12 @@ namespace AccessibleArena.Core.Services
 
             if (success)
             {
+                // Update our tracked lists immediately so a follow-up Tab + Enter on the
+                // same card (the natural "deselect" gesture) sees the new zone instead of
+                // the pre-move one and toggles it back. The delayed refresh below is kept
+                // as the authoritative reconcile against the game's state.
+                MoveCardBetweenZonesEagerly(card, cardZone);
+
                 // Announce the move
                 string newZoneName = cardZone == BrowserZoneType.Top
                     ? GetZoneName(BrowserZoneType.Bottom)


### PR DESCRIPTION
## Summary

Surveil's zone tracking was broken end-to-end:

- Every card read as `keep` regardless of where it had been moved.
- Tab announcements lied about the selection state.
- Tab + Enter on an already-milled card retried the same direction instead of toggling back to the library — there was no way to undo a selection short of cancelling the whole browser.

## Root cause

`RefreshSurveilCardLists` walked `BrowserCardHolder_ViewDismiss` looking for cards on the bottom-zone side. Surveil doesn't use that holder — both zones live in a single `cardHolder`, with `SurveilBrowser` tracking the split in two internal `List<DuelScene_CDC>` fields (`libraryGroup` and `graveyardGroup`) and exposing them via public `GetLibraryCards()` / `GetGraveyardCards()` getters. Walking the non-existent ViewDismiss holder produced an empty `_bottomCards` list, so every card was found in `_topCards` first by `DetectCardZone` and reported as `Top`.

## Changes

- **`RefreshSurveilCardLists`** now reads `GetLibraryCards()` and `GetGraveyardCards()` off the active `SurveilBrowser` controller directly (same source the browser's own multi-layout queries when positioning cards). A small `FillFromCdcList` helper copies the resulting GameObjects into the tracked list and filters out the `InstanceId == 0` placeholder card SurveilBrowser inserts into `libraryGroup`.
- **`MoveCardBetweenZonesEagerly`** is a new private helper called from both `ActivateCurrentCard` (zone-nav Enter) and `ActivateCardFromGenericNavigation` (Tab + Enter). It updates `_topCards` / `_bottomCards` the instant a move succeeds so `DetectCardZone` is correct during the 0.2 s window before the reconciling `RefreshCardLists` coroutine fires. Scry was already correct after the delay but stale within it; this closes that equivalent gap.

The delayed `RefreshCardLists` coroutine remains as the authoritative reconcile against the game's state — if anything drifts, the next refresh restores the truth.

## Test plan

- [x] `dotnet build src/AccessibleArena.csproj` — clean, 0 warnings.
- [x] `dotnet test tests/AccessibleArena.Tests` — 150/150 pass.
- [x] In-game (Surveil 1): Enter on a card announces `moved to graveyard`, Tab now announces `graveyard` (was `keep`), Tab + Enter announces `moved to keep on top` and the card returns to the library, C/D zones reflect the current split correctly.
- [x] In-game (Scry, regression check): existing flow still works — card moves between zones with proper announcements, C and D show the card in the correct zone.

## Notes

This is independent of PR #98 (Surveil "graveyard" wording) but will conflict in `docs/CHANGELOG.md` if landed in a different order — both add the same `## v1.3` section header. Trivial to resolve by keeping the header once and merging the bullet lists.