### PR TITLE
fix(mana): announce 0-cost cards as free, not their printed cost

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Accessible Arena.
 
+## v1.3
+
+Bug fixes:
+
+- 0-cost cards are now announced correctly. PR #91 wired in the live cast-action cost so reducers (Warden of Evos Isle, Goblin Electromancer, etc.) would be reflected, but treated a length-0 `Action.ManaCost` as "not yet resolved" and skipped past it — falling all the way back to `PrintedCastingCost`. The result: a card discounted to 0 still read its printed cost, so a "free" cast announced as costing one mana the player would never actually pay. Empty live-action cost is now the real 0-cost signal (cost reducers brought the spell to free, or it's a Suspend/Cascade exile cast, or it's a printed-0 artifact like Memnite); `ParseManaQuantityArray` renders an empty mana-quantity array as the localized `ManaFree` ("Free" in English), short-circuiting the fallback chain. Mana-cost block is now read for printed-0-cost cards too (Memnite, Mox Amber, Ornithopter) instead of being silently omitted.
+
 ## v1.2
 
 Duel:

--- a/docs/CONTRIBUTING_TRANSLATIONS.md
+++ b/docs/CONTRIBUTING_TRANSLATIONS.md
@@ -354,7 +354,7 @@ Spoken names for mana symbols on cards.
 | `ManaX` | "X" | | Variable mana (X) |
 | `ManaSnow` | "Snow" | | Snow mana (S) |
 | `ManaEnergy` | "Energy" | | Energy counter (E) |
-| `ManaPhyrexian_Format` | "Phyrexian {0}" | {0} = color name | Phyrexian mana (e.g., "Phyrexian Red") |
+| `ManaFree` | "Free" | | Used as the whole mana-cost line for cards costing 0 — both printed zero-cost cards (Memnite, Mox Amber) and cards discounted to 0 by cost reducers / Suspend / Cascade. Pick whatever word your locale uses for "free spell" or "no cost" — short and unambiguous when announced after "Mana Cost:". |
 | `ManaHybrid_Format` | "{0} or {1}" | {0} = color 1, {1} = color 2 | Hybrid mana (e.g., "White or Blue") |
 
 ### Settings Menu (F2)

--- a/docs/CONTRIBUTING_TRANSLATIONS.md
+++ b/docs/CONTRIBUTING_TRANSLATIONS.md
@@ -355,6 +355,7 @@ Spoken names for mana symbols on cards.
 | `ManaSnow` | "Snow" | | Snow mana (S) |
 | `ManaEnergy` | "Energy" | | Energy counter (E) |
 | `ManaFree` | "Free" | | Used as the whole mana-cost line for cards costing 0 — both printed zero-cost cards (Memnite, Mox Amber) and cards discounted to 0 by cost reducers / Suspend / Cascade. Pick whatever word your locale uses for "free spell" or "no cost" — short and unambiguous when announced after "Mana Cost:". |
+| `ManaPhyrexian_Format` | "Phyrexian {0}" | {0} = color name | Phyrexian mana (e.g., "Phyrexian Red") |
 | `ManaHybrid_Format` | "{0} or {1}" | {0} = color 1, {1} = color 2 | Hybrid mana (e.g., "White or Blue") |
 
 ### Settings Menu (F2)

--- a/lang/de.json
+++ b/lang/de.json
@@ -261,6 +261,7 @@
   "ManaSnow": "Schnee",
   "ManaEnergy": "Energie",
   "ManaGeneric": "Generisch",
+  "ManaFree": "Kostenlos",
   "ManaPhyrexian": "Phyrexianisch",
   "ManaPhyrexian_Format": "Phyrexianisches {0}",
   "ManaHybrid_Format": "{0} oder {1}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -261,6 +261,7 @@
   "ManaSnow": "Snow",
   "ManaEnergy": "Energy",
   "ManaGeneric": "Generic",
+  "ManaFree": "Free",
   "ManaPhyrexian": "Phyrexian",
   "ManaPhyrexian_Format": "Phyrexian {0}",
   "ManaHybrid_Format": "{0} or {1}",

--- a/lang/es.json
+++ b/lang/es.json
@@ -261,6 +261,7 @@
   "ManaSnow": "Nieve",
   "ManaEnergy": "Energía",
   "ManaGeneric": "Genérico",
+  "ManaFree": "Gratis",
   "ManaPhyrexian": "Phyrexiano",
   "ManaPhyrexian_Format": "Phyrexiano {0}",
   "ManaHybrid_Format": "{0} o {1}",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -261,6 +261,7 @@
   "ManaSnow": "Neige",
   "ManaEnergy": "Énergie",
   "ManaGeneric": "Générique",
+  "ManaFree": "Gratuit",
   "ManaPhyrexian": "Phyrexian",
   "ManaPhyrexian_Format": "Phyrexian {0}",
   "ManaHybrid_Format": "{0} ou {1}",

--- a/lang/it.json
+++ b/lang/it.json
@@ -261,6 +261,7 @@
   "ManaSnow": "Neve",
   "ManaEnergy": "Energia",
   "ManaGeneric": "Generico",
+  "ManaFree": "Gratis",
   "ManaPhyrexian": "Phyrexiano",
   "ManaPhyrexian_Format": "Phyrexiano {0}",
   "ManaHybrid_Format": "{0} o {1}",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -261,6 +261,7 @@
   "ManaSnow": "氷雪",
   "ManaEnergy": "エネルギー",
   "ManaGeneric": "不特定",
+  "ManaFree": "無料",
   "ManaPhyrexian": "ファイレクシアン",
   "ManaPhyrexian_Format": "ファイレクシアン{0}",
   "ManaHybrid_Format": "{0}または{1}",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -261,6 +261,7 @@
   "ManaSnow": "눈",
   "ManaEnergy": "에너지",
   "ManaGeneric": "무색",
+  "ManaFree": "무료",
   "ManaPhyrexian": "피렉시아",
   "ManaPhyrexian_Format": "피렉시아 {0}",
   "ManaHybrid_Format": "{0} 또는 {1}",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -261,6 +261,7 @@
   "ManaSnow": "Śnieg",
   "ManaEnergy": "Energia",
   "ManaGeneric": "Ogólna",
+  "ManaFree": "Za darmo",
   "ManaPhyrexian": "Phyrexiańska",
   "ManaPhyrexian_Format": "Phyrexiańska {0}",
   "ManaHybrid_Format": "{0} lub {1}",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -261,6 +261,7 @@
   "ManaSnow": "Neve",
   "ManaEnergy": "Energia",
   "ManaGeneric": "Genérico",
+  "ManaFree": "Grátis",
   "ManaPhyrexian": "Phyrexiano",
   "ManaPhyrexian_Format": "Phyrexiano {0}",
   "ManaHybrid_Format": "{0} ou {1}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -261,6 +261,7 @@
   "ManaSnow": "Снежная",
   "ManaEnergy": "Энергия",
   "ManaGeneric": "Общая",
+  "ManaFree": "Бесплатно",
   "ManaPhyrexian": "Фирексийская",
   "ManaPhyrexian_Format": "Фирексийская {0}",
   "ManaHybrid_Format": "{0} или {1}",

--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -261,6 +261,7 @@
   "ManaSnow": "雪境",
   "ManaEnergy": "能量",
   "ManaGeneric": "通用",
+  "ManaFree": "免费",
   "ManaPhyrexian": "非瑞克西亚",
   "ManaPhyrexian_Format": "非瑞克西亚{0}",
   "ManaHybrid_Format": "{0}或{1}",

--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -261,6 +261,7 @@
   "ManaSnow": "雪境",
   "ManaEnergy": "能量",
   "ManaGeneric": "通用",
+  "ManaFree": "免費",
   "ManaPhyrexian": "非瑞克西亞",
   "ManaPhyrexian_Format": "非瑞克西亞{0}",
   "ManaHybrid_Format": "{0}或{1}",

--- a/src/Core/Models/Strings.cs
+++ b/src/Core/Models/Strings.cs
@@ -853,6 +853,7 @@ namespace AccessibleArena.Core.Models
         public static string ManaSnow => L.Get("ManaSnow");
         public static string ManaEnergy => L.Get("ManaEnergy");
         public static string ManaGeneric => L.Get("ManaGeneric");
+        public static string ManaFree => L.Get("ManaFree");
         public static string ManaPhyrexianBare => L.Get("ManaPhyrexian");
         public static string ManaPhyrexian(string color) => L.Format("ManaPhyrexian_Format", color);
         public static string ManaHybrid(string color1, string color2) => L.Format("ManaHybrid_Format", color1, color2);

--- a/src/Core/Services/CardModelProvider.cs
+++ b/src/Core/Services/CardModelProvider.cs
@@ -1050,9 +1050,11 @@ namespace AccessibleArena.Core.Services
                     var manaCost = _actionManaCostProp.GetValue(action);
                     if (!(manaCost is IEnumerable manaCostEnum)) continue;
 
-                    // RepeatedField<ManaRequirement> of length 0 means "free cast" or "not yet
-                    // resolved" — skip and let the next action / printed-cost fallback handle it.
-                    if (!manaCostEnum.Cast<object>().Any()) continue;
+                    // Length 0 = the cost has been reduced all the way to free (cost reducers,
+                    // Suspend / Cascade / "play without paying", etc). The game's own tile
+                    // renderer treats this as 0 and we should too — falling through to the
+                    // printed cost here would announce a fee the player will never pay.
+                    if (!manaCostEnum.Cast<object>().Any()) return manaCostEnum;
 
                     var convertedList = InvokeConvertManaCostsToList(manaCostEnum);
                     if (convertedList != null) return convertedList;

--- a/src/Core/Services/ManaTextFormatter.cs
+++ b/src/Core/Services/ManaTextFormatter.cs
@@ -190,15 +190,19 @@ namespace AccessibleArena.Core.Services
         /// </summary>
         internal static string ParseManaQuantityArray(IEnumerable manaQuantities)
         {
+            if (manaQuantities == null) return null;
+
             // Track colored mana grouped by symbol label (insertion-ordered)
             var colorCounts = new Dictionary<string, int>();
             var colorOrder = new List<string>();
             // Hybrid/Phyrexian symbols are kept as individual entries (can't be meaningfully grouped)
             var complexSymbols = new List<string>();
             int genericCount = 0;
+            bool sawAny = false;
 
             foreach (var mq in manaQuantities)
             {
+                sawAny = true;
                 if (mq == null) continue;
 
                 var mqType = mq.GetType();
@@ -300,7 +304,12 @@ namespace AccessibleArena.Core.Services
             // Complex symbols (hybrid, phyrexian) appended individually
             parts.AddRange(complexSymbols);
 
-            return parts.Count > 0 ? string.Join(", ", parts) : null;
+            if (parts.Count > 0) return string.Join(", ", parts);
+
+            // Empty input → genuinely free (cost discounted to 0, Suspend/Cascade exile cast,
+            // printed-0 artifacts like Memnite). Non-empty input that parsed to nothing falls
+            // through to null so the caller can try a different cost source.
+            return sawAny ? null : Strings.ManaFree;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Followup to #91 (live cast-action cost replaces printed cost when reducers are active). That fix treated a length-0 `Action.ManaCost` as a "not yet resolved" placeholder and skipped past it, falling all the way back to `PrintedCastingCost`. The result: a card discounted to 0 still read its printed cost — a free cast announced as one mana the player would never actually pay.

Reproduced in-game with a deck that stacks reducers; the announcement now reads "Mana Cost: Free" and the card casts for nothing as expected.

## Changes

- **`CardModelProvider.TryGetLiveCastActionManaCost`** — replaced the `continue` on empty `Action.ManaCost` with `return manaCostEnum`. Empty is the real 0-cost signal (cost reducers brought the spell to free, or Suspend / Cascade / "play without paying"), matching what the game's own tile renderer treats as 0.
- **`ManaTextFormatter.ParseManaQuantityArray`** — empty input now returns the localized `ManaFree` string instead of `null`. A `sawAny` flag distinguishes "input was empty" (truly 0-cost) from "input had entries that failed to parse" (still returns `null` so the caller can try a different cost source).
- **`Strings.ManaFree`** + entry in all 12 lang files. Documented in `CONTRIBUTING_TRANSLATIONS.md`.

## Side benefit

Printed-0-cost cards (Memnite, Mox Amber, Ornithopter, Phyrexian Walker, etc.) now have a Mana Cost block read aloud instead of being silently omitted — they share the same empty-array shape and benefit from the same handling. Arrow Down past Name + Type now reaches a "Mana Cost: Free" block before falling into rules text, where it used to skip straight from Type to Rules.

## Test plan

- [x] `dotnet build src/AccessibleArena.csproj` — clean, 0 warnings.
- [x] `dotnet test tests/AccessibleArena.Tests` — 150/150 pass (locale alignment test verifies the new `ManaFree` key exists in all 12 locales).
- [x] In-game: a card the user's deck discounted to 0 now announces "Mana Cost: Free" instead of "1 blue" / similar, and casts without tapping any lands.
- [ ] (Recommended) Sanity check: a non-discounted card still reads its real cost (e.g., `1 generic, blue`).
- [ ] (Recommended) Bonus check: a printed-0-cost card (Memnite if you have one) now reads "Mana Cost: Free" — previously the block was silently omitted.

## Notes

Will conflict in `docs/CHANGELOG.md` with PRs #98 and #100 (both add a `## v1.3` section header). Trivial to resolve — keep the header once, merge the bullet lists.